### PR TITLE
feat: completed local disvoery explore page with expo-location 

### DIFF
--- a/Buyinz/app/(tabs)/explore.tsx
+++ b/Buyinz/app/(tabs)/explore.tsx
@@ -1,112 +1,517 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
 import { Image } from 'expo-image';
-import { Platform, StyleSheet } from 'react-native';
+import * as Location from 'expo-location';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Ionicons } from '@expo/vector-icons';
 
-import { Collapsible } from '@/components/ui/collapsible';
-import { ExternalLink } from '@/components/external-link';
-import ParallaxScrollView from '@/components/parallax-scroll-view';
-import { ThemedText } from '@/components/themed-text';
-import { ThemedView } from '@/components/themed-view';
-import { IconSymbol } from '@/components/ui/icon-symbol';
-import { Fonts } from '@/constants/theme';
+import { Brand, Colors, Fonts } from '@/constants/theme';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import {
+  DEFAULT_PITTSBURGH_COORDS,
+  fetchDiscoveryFeed,
+  type DiscoverySalePost,
+  type GeoPoint,
+} from '@/supabase/queries';
 
-export default function TabTwoScreen() {
+const SHELVES = [
+  { id: 'All', label: 'All Shelves', emoji: '🏪' },
+  { id: 'Furniture', label: 'Furniture', emoji: '🛋️' },
+  { id: 'Clothing', label: 'Clothing', emoji: '👗' },
+  { id: 'Electronics', label: 'Electronics', emoji: '📱' },
+  { id: 'Books', label: 'Books', emoji: '📚' },
+  { id: 'Decor', label: 'Decor', emoji: '🪴' },
+  { id: 'Other', label: 'Other', emoji: '📦' },
+] as const;
+
+type ShelfId = (typeof SHELVES)[number]['id'];
+
+const TRENDING_TAGS = [
+  '#VintageSteelers',
+  '#MCM',
+  '#PittMovingSale',
+  '#ThriftFinds',
+  '#Vinyl',
+  '#ISO',
+];
+
+const RADIUS_OPTIONS: { label: string; miles: number }[] = [
+  { label: 'Neighborhood', miles: 0 },
+  { label: '5 mi', miles: 5 },
+  { label: '10 mi', miles: 10 },
+  { label: '20 mi', miles: 20 },
+];
+
+function milesBetween(a: GeoPoint, b: GeoPoint): number {
+  const earthRadiusMiles = 3958.8;
+  const dLat = ((b.latitude - a.latitude) * Math.PI) / 180;
+  const dLon = ((b.longitude - a.longitude) * Math.PI) / 180;
+  const lat1 = (a.latitude * Math.PI) / 180;
+  const lat2 = (b.latitude * Math.PI) / 180;
+
+  const h =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.sin(dLon / 2) * Math.sin(dLon / 2) * Math.cos(lat1) * Math.cos(lat2);
+
+  return 2 * earthRadiusMiles * Math.asin(Math.sqrt(h));
+}
+
+function ExploreCard({ post }: { post: DiscoverySalePost }) {
+  const scheme = useColorScheme() ?? 'light';
+  const colors = Colors[scheme];
+
   return (
-    <ParallaxScrollView
-      headerBackgroundColor={{ light: '#D0D0D0', dark: '#353636' }}
-      headerImage={
-        <IconSymbol
-          size={310}
-          color="#808080"
-          name="chevron.left.forwardslash.chevron.right"
-          style={styles.headerImage}
-        />
-      }>
-      <ThemedView style={styles.titleContainer}>
-        <ThemedText
-          type="title"
-          style={{
-            fontFamily: Fonts.rounded,
-          }}>
-          Explore
-        </ThemedText>
-      </ThemedView>
-      <ThemedText>This app includes example code to help you get started.</ThemedText>
-      <Collapsible title="File-based routing">
-        <ThemedText>
-          This app has two screens:{' '}
-          <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> and{' '}
-          <ThemedText type="defaultSemiBold">app/(tabs)/explore.tsx</ThemedText>
-        </ThemedText>
-        <ThemedText>
-          The layout file in <ThemedText type="defaultSemiBold">app/(tabs)/_layout.tsx</ThemedText>{' '}
-          sets up the tab navigator.
-        </ThemedText>
-        <ExternalLink href="https://docs.expo.dev/router/introduction">
-          <ThemedText type="link">Learn more</ThemedText>
-        </ExternalLink>
-      </Collapsible>
-      <Collapsible title="Android, iOS, and web support">
-        <ThemedText>
-          You can open this project on Android, iOS, and the web. To open the web version, press{' '}
-          <ThemedText type="defaultSemiBold">w</ThemedText> in the terminal running this project.
-        </ThemedText>
-      </Collapsible>
-      <Collapsible title="Images">
-        <ThemedText>
-          For static images, you can use the <ThemedText type="defaultSemiBold">@2x</ThemedText> and{' '}
-          <ThemedText type="defaultSemiBold">@3x</ThemedText> suffixes to provide files for
-          different screen densities
-        </ThemedText>
-        <Image
-          source={require('@/assets/images/react-logo.png')}
-          style={{ width: 100, height: 100, alignSelf: 'center' }}
-        />
-        <ExternalLink href="https://reactnative.dev/docs/images">
-          <ThemedText type="link">Learn more</ThemedText>
-        </ExternalLink>
-      </Collapsible>
-      <Collapsible title="Light and dark mode components">
-        <ThemedText>
-          This template has light and dark mode support. The{' '}
-          <ThemedText type="defaultSemiBold">useColorScheme()</ThemedText> hook lets you inspect
-          what the user&apos;s current color scheme is, and so you can adjust UI colors accordingly.
-        </ThemedText>
-        <ExternalLink href="https://docs.expo.dev/develop/user-interface/color-themes/">
-          <ThemedText type="link">Learn more</ThemedText>
-        </ExternalLink>
-      </Collapsible>
-      <Collapsible title="Animations">
-        <ThemedText>
-          This template includes an example of an animated component. The{' '}
-          <ThemedText type="defaultSemiBold">components/HelloWave.tsx</ThemedText> component uses
-          the powerful{' '}
-          <ThemedText type="defaultSemiBold" style={{ fontFamily: Fonts.mono }}>
-            react-native-reanimated
-          </ThemedText>{' '}
-          library to create a waving hand animation.
-        </ThemedText>
-        {Platform.select({
-          ios: (
-            <ThemedText>
-              The <ThemedText type="defaultSemiBold">components/ParallaxScrollView.tsx</ThemedText>{' '}
-              component provides a parallax effect for the header image.
-            </ThemedText>
-          ),
-        })}
-      </Collapsible>
-    </ParallaxScrollView>
+    <View
+      style={[
+        styles.card,
+        {
+          backgroundColor: colors.card,
+          borderColor: colors.border,
+        },
+      ]}
+    >
+      <Image source={{ uri: post.images[0] }} style={styles.cardImage} contentFit="cover" />
+
+      <View style={styles.cardOverlayTop}>
+        <View style={styles.pricePill}>
+          <Text style={styles.priceText}>{post.price === 0 ? 'Offer' : `$${post.price}`}</Text>
+        </View>
+      </View>
+
+      <View style={styles.cardOverlayBottom}>
+        <Text style={styles.cardTitle} numberOfLines={2}>
+          {post.title}
+        </Text>
+        <View style={styles.metaRow}>
+          <View style={styles.neighborhoodPill}>
+            <Text style={styles.neighborhoodText}>{post.neighborhoodTag}</Text>
+          </View>
+          <Text style={styles.distanceText}>{post.distanceMiles.toFixed(1)} mi</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export default function ExploreTabScreen() {
+  const scheme = useColorScheme() ?? 'light';
+  const colors = Colors[scheme];
+  const insets = useSafeAreaInsets();
+
+  const [search, setSearch] = useState('');
+  const [activeCategory, setActiveCategory] = useState<ShelfId>('All');
+  const [activeTag, setActiveTag] = useState<string | null>(null);
+  const [activeRadius, setActiveRadius] = useState(0);
+
+  const [userCoords, setUserCoords] = useState<GeoPoint>(DEFAULT_PITTSBURGH_COORDS);
+  const [neighborhood, setNeighborhood] = useState('Pittsburgh');
+  const [listings, setListings] = useState<DiscoverySalePost[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const lastCoordsRef = useRef<GeoPoint>(DEFAULT_PITTSBURGH_COORDS);
+
+  useEffect(() => {
+    let mounted = true;
+    let subscription: Location.LocationSubscription | null = null;
+
+    (async () => {
+      try {
+        const { status } = await Location.requestForegroundPermissionsAsync();
+
+        if (status === 'granted') {
+          const current = await Location.getCurrentPositionAsync({
+            accuracy: Location.Accuracy.Balanced,
+          });
+
+          const nextCoords: GeoPoint = {
+            latitude: current.coords.latitude,
+            longitude: current.coords.longitude,
+          };
+
+          if (mounted) {
+            lastCoordsRef.current = nextCoords;
+            setUserCoords(nextCoords);
+          }
+
+          subscription = await Location.watchPositionAsync(
+            {
+              accuracy: Location.Accuracy.Balanced,
+              distanceInterval: 400,
+              timeInterval: 20000,
+            },
+            (position: Location.LocationObject) => {
+              const next: GeoPoint = {
+                latitude: position.coords.latitude,
+                longitude: position.coords.longitude,
+              };
+
+              const movedMiles = milesBetween(lastCoordsRef.current, next);
+              if (movedMiles >= 1) {
+                lastCoordsRef.current = next;
+                setUserCoords(next);
+              }
+            },
+          );
+        }
+      } catch {
+        // Fall back to default Pittsburgh center.
+      }
+    })();
+
+    return () => {
+      mounted = false;
+      subscription?.remove();
+    };
+  }, []);
+
+  useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+
+    fetchDiscoveryFeed({ userCoords, radiusMiles: activeRadius })
+      .then((result) => {
+        if (!mounted) return;
+        setNeighborhood(result.neighborhood);
+        setListings(result.listings);
+      })
+      .catch(console.error)
+      .finally(() => {
+        if (mounted) setLoading(false);
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, [activeRadius, userCoords]);
+
+  const filtered = useMemo(() => {
+    return listings.filter((post) => {
+      const matchesCategory = activeCategory === 'All' || post.category === activeCategory;
+      const q = search.trim().toLowerCase();
+      const matchesSearch =
+        q.length === 0 ||
+        post.title.toLowerCase().includes(q) ||
+        post.seller.username.toLowerCase().includes(q);
+      const matchesTag = activeTag == null || post.hashtags.includes(activeTag);
+      return matchesCategory && matchesSearch && matchesTag;
+    });
+  }, [activeCategory, activeTag, listings, search]);
+
+  const [leftCol, rightCol] = useMemo(() => {
+    const left: DiscoverySalePost[] = [];
+    const right: DiscoverySalePost[] = [];
+
+    filtered.forEach((post, idx) => {
+      if (idx % 2 === 0) {
+        left.push(post);
+      } else {
+        right.push(post);
+      }
+    });
+
+    return [left, right];
+  }, [filtered]);
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <View
+        style={[
+          styles.header,
+          {
+            paddingTop: insets.top + 12,
+            backgroundColor: colors.background,
+            borderBottomColor: colors.border,
+          },
+        ]}
+      >
+        <Text style={[styles.title, { color: colors.text, fontFamily: Fonts.rounded }]}>Discover</Text>
+        <Text style={[styles.subtitle, { color: colors.textSecondary }]}>Trending in {neighborhood}</Text>
+
+        <View style={[styles.searchWrap, { backgroundColor: colors.card, borderColor: colors.border }]}> 
+          <Ionicons name="search" size={16} color={colors.textSecondary} />
+          <TextInput
+            value={search}
+            onChangeText={setSearch}
+            placeholder="Search Buyinz listings..."
+            placeholderTextColor={colors.textSecondary}
+            style={[styles.searchInput, { color: colors.text }]}
+          />
+          {search.length > 0 && (
+            <Pressable onPress={() => setSearch('')}>
+              <Ionicons name="close" size={16} color={colors.textSecondary} />
+            </Pressable>
+          )}
+        </View>
+
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.chipsRow}>
+          {RADIUS_OPTIONS.map((option) => {
+            const selected = option.miles === activeRadius;
+            return (
+              <Pressable
+                key={option.label}
+                onPress={() => setActiveRadius(option.miles)}
+                style={[
+                  styles.radiusChip,
+                  selected
+                    ? { backgroundColor: Brand.primary, borderColor: Brand.primary }
+                    : { backgroundColor: colors.card, borderColor: colors.border },
+                ]}
+              >
+                <Text style={[styles.radiusChipText, { color: selected ? '#FFFFFF' : colors.text }]}>
+                  {option.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.chipsRow}>
+          {SHELVES.map((shelf) => {
+            const selected = shelf.id === activeCategory;
+            return (
+              <Pressable
+                key={shelf.id}
+                onPress={() => setActiveCategory(shelf.id)}
+                style={[
+                  styles.chip,
+                  selected
+                    ? { backgroundColor: Brand.primary, borderColor: Brand.primary }
+                    : { backgroundColor: colors.card, borderColor: colors.border },
+                ]}
+              >
+                <Text style={[styles.chipText, { color: selected ? '#FFFFFF' : colors.text }]}>
+                  {shelf.emoji} {shelf.label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.chipsRow}>
+          {TRENDING_TAGS.map((tag) => {
+            const selected = activeTag === tag;
+            return (
+              <Pressable
+                key={tag}
+                onPress={() => setActiveTag((prev) => (prev === tag ? null : tag))}
+                style={[
+                  styles.tagChip,
+                  selected
+                    ? { backgroundColor: `${Brand.primary}22`, borderColor: Brand.primary }
+                    : { backgroundColor: colors.card, borderColor: colors.border },
+                ]}
+              >
+                <Text style={[styles.tagChipText, { color: selected ? Brand.primary : colors.textSecondary }]}>
+                  {tag}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+      </View>
+
+      {loading ? (
+        <View style={styles.loader}>
+          <ActivityIndicator size="large" color={Brand.primary} />
+        </View>
+      ) : filtered.length === 0 ? (
+        <View style={styles.emptyWrap}>
+          <Text style={[styles.emptyTitle, { color: colors.text }]}>No listings found</Text>
+          <Text style={[styles.emptyText, { color: colors.textSecondary }]}>Try another shelf, tag, or radius.</Text>
+        </View>
+      ) : (
+        <ScrollView contentContainerStyle={styles.feedContent} showsVerticalScrollIndicator={false}>
+          <View style={styles.gridRow}>
+            <View style={styles.column}>
+              {leftCol.map((post) => (
+                <ExploreCard key={post.id} post={post} />
+              ))}
+            </View>
+            <View style={[styles.column, styles.offsetColumn]}>
+              {rightCol.map((post) => (
+                <ExploreCard key={post.id} post={post} />
+              ))}
+            </View>
+          </View>
+        </ScrollView>
+      )}
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  headerImage: {
-    color: '#808080',
-    bottom: -90,
-    left: -35,
-    position: 'absolute',
+  container: {
+    flex: 1,
   },
-  titleContainer: {
+  header: {
+    borderBottomWidth: 1,
+    paddingHorizontal: 14,
+    paddingBottom: 12,
+    gap: 10,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '800',
+    lineHeight: 34,
+  },
+  subtitle: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  searchWrap: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    height: 42,
+    gap: 8,
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 14,
+  },
+  chipsRow: {
+    gap: 8,
+    paddingRight: 20,
+  },
+  radiusChip: {
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+  },
+  radiusChipText: {
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  chip: {
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+  },
+  chipText: {
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  tagChip: {
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 7,
+  },
+  tagChipText: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  loader: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  emptyWrap: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 20,
+    gap: 6,
+  },
+  emptyTitle: {
+    fontSize: 17,
+    fontWeight: '700',
+  },
+  emptyText: {
+    fontSize: 13,
+    textAlign: 'center',
+  },
+  feedContent: {
+    paddingHorizontal: 10,
+    paddingTop: 12,
+    paddingBottom: 120,
+  },
+  gridRow: {
     flexDirection: 'row',
     gap: 8,
+    alignItems: 'flex-start',
+  },
+  column: {
+    flex: 1,
+    gap: 8,
+  },
+  offsetColumn: {
+    marginTop: 18,
+  },
+  card: {
+    borderWidth: 1,
+    borderRadius: 14,
+    overflow: 'hidden',
+    minHeight: 230,
+  },
+  cardImage: {
+    width: '100%',
+    aspectRatio: 3 / 4,
+  },
+  cardOverlayTop: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+  },
+  pricePill: {
+    backgroundColor: Brand.primary,
+    borderRadius: 999,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+  },
+  priceText: {
+    color: '#FFFFFF',
+    fontSize: 12,
+    fontWeight: '800',
+  },
+  cardOverlayBottom: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    paddingHorizontal: 10,
+    paddingVertical: 9,
+    backgroundColor: 'rgba(0,0,0,0.58)',
+    gap: 6,
+  },
+  cardTitle: {
+    color: '#FFFFFF',
+    fontSize: 12,
+    fontWeight: '700',
+    lineHeight: 16,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+  },
+  neighborhoodPill: {
+    backgroundColor: 'rgba(255,255,255,0.24)',
+    borderRadius: 999,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+  },
+  neighborhoodText: {
+    color: '#FFFFFF',
+    fontSize: 11,
+    fontWeight: '700',
+  },
+  distanceText: {
+    color: '#FFFFFF',
+    fontSize: 11,
+    fontWeight: '700',
   },
 });

--- a/Buyinz/lib/discoveryLocation.ts
+++ b/Buyinz/lib/discoveryLocation.ts
@@ -1,0 +1,168 @@
+export interface GeoPoint {
+  latitude: number;
+  longitude: number;
+}
+
+interface NeighborhoodPolygon {
+  name: string;
+  points: GeoPoint[];
+  center: GeoPoint;
+}
+
+export const DEFAULT_PITTSBURGH_COORDS: GeoPoint = {
+  latitude: 40.4406,
+  longitude: -79.9959,
+};
+
+const PITTSBURGH_NEIGHBORHOODS: NeighborhoodPolygon[] = [
+  {
+    name: 'Oakland',
+    points: [
+      { latitude: 40.4526, longitude: -79.9748 },
+      { latitude: 40.4488, longitude: -79.9567 },
+      { latitude: 40.4341, longitude: -79.9601 },
+      { latitude: 40.435, longitude: -79.9806 },
+    ],
+    center: { latitude: 40.4407, longitude: -79.9594 },
+  },
+  {
+    name: 'Shadyside',
+    points: [
+      { latitude: 40.4622, longitude: -79.9457 },
+      { latitude: 40.4572, longitude: -79.9248 },
+      { latitude: 40.4462, longitude: -79.9284 },
+      { latitude: 40.4482, longitude: -79.9468 },
+    ],
+    center: { latitude: 40.4518, longitude: -79.9358 },
+  },
+  {
+    name: 'Squirrel Hill',
+    points: [
+      { latitude: 40.4468, longitude: -79.9365 },
+      { latitude: 40.4398, longitude: -79.9106 },
+      { latitude: 40.4248, longitude: -79.9153 },
+      { latitude: 40.4289, longitude: -79.9402 },
+    ],
+    center: { latitude: 40.4342, longitude: -79.9222 },
+  },
+  {
+    name: 'Lawrenceville',
+    points: [
+      { latitude: 40.4852, longitude: -79.9723 },
+      { latitude: 40.4802, longitude: -79.9395 },
+      { latitude: 40.466, longitude: -79.9445 },
+      { latitude: 40.4687, longitude: -79.9766 },
+    ],
+    center: { latitude: 40.4741, longitude: -79.9563 },
+  },
+  {
+    name: 'Strip District',
+    points: [
+      { latitude: 40.4572, longitude: -80.0121 },
+      { latitude: 40.4555, longitude: -79.9767 },
+      { latitude: 40.4451, longitude: -79.9798 },
+      { latitude: 40.4467, longitude: -80.0116 },
+    ],
+    center: { latitude: 40.4508, longitude: -79.9913 },
+  },
+  {
+    name: 'North Side',
+    points: [
+      { latitude: 40.4648, longitude: -80.0264 },
+      { latitude: 40.4662, longitude: -79.9911 },
+      { latitude: 40.4462, longitude: -79.9939 },
+      { latitude: 40.4455, longitude: -80.0258 },
+    ],
+    center: { latitude: 40.4542, longitude: -80.0078 },
+  },
+  {
+    name: 'Mount Washington',
+    points: [
+      { latitude: 40.4442, longitude: -80.0222 },
+      { latitude: 40.4382, longitude: -79.9968 },
+      { latitude: 40.4216, longitude: -80.0018 },
+      { latitude: 40.4236, longitude: -80.0273 },
+    ],
+    center: { latitude: 40.4326, longitude: -80.0109 },
+  },
+  {
+    name: 'Point Breeze',
+    points: [
+      { latitude: 40.4586, longitude: -79.9203 },
+      { latitude: 40.4538, longitude: -79.8961 },
+      { latitude: 40.4418, longitude: -79.8998 },
+      { latitude: 40.4446, longitude: -79.9232 },
+    ],
+    center: { latitude: 40.4501, longitude: -79.9108 },
+  },
+];
+
+const LOCATION_TO_COORDINATE: { match: string; point: GeoPoint }[] = [
+  { match: 'oakland', point: { latitude: 40.4407, longitude: -79.9594 } },
+  { match: 'shadyside', point: { latitude: 40.4518, longitude: -79.9358 } },
+  { match: 'squirrel hill', point: { latitude: 40.4342, longitude: -79.9222 } },
+  { match: 'lawrenceville', point: { latitude: 40.4741, longitude: -79.9563 } },
+  { match: 'strip district', point: { latitude: 40.4508, longitude: -79.9913 } },
+  { match: 'north side', point: { latitude: 40.4542, longitude: -80.0078 } },
+  { match: 'mount washington', point: { latitude: 40.4326, longitude: -80.0109 } },
+  { match: 'point breeze', point: { latitude: 40.4501, longitude: -79.9108 } },
+];
+
+export function milesBetween(a: GeoPoint, b: GeoPoint): number {
+  const earthRadiusMiles = 3958.8;
+  const dLat = ((b.latitude - a.latitude) * Math.PI) / 180;
+  const dLon = ((b.longitude - a.longitude) * Math.PI) / 180;
+  const lat1 = (a.latitude * Math.PI) / 180;
+  const lat2 = (b.latitude * Math.PI) / 180;
+
+  const h =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.sin(dLon / 2) * Math.sin(dLon / 2) * Math.cos(lat1) * Math.cos(lat2);
+
+  return 2 * earthRadiusMiles * Math.asin(Math.sqrt(h));
+}
+
+export function isPointInPolygon(point: GeoPoint, polygon: GeoPoint[]): boolean {
+  let inside = false;
+  const x = point.longitude;
+  const y = point.latitude;
+
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const xi = polygon[i].longitude;
+    const yi = polygon[i].latitude;
+    const xj = polygon[j].longitude;
+    const yj = polygon[j].latitude;
+
+    const intersects =
+      yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi + Number.EPSILON) + xi;
+    if (intersects) inside = !inside;
+  }
+
+  return inside;
+}
+
+export function resolveNeighborhood(point: GeoPoint): string {
+  const containing = PITTSBURGH_NEIGHBORHOODS.find((hood) =>
+    isPointInPolygon(point, hood.points),
+  );
+  if (containing) return containing.name;
+
+  let nearest = PITTSBURGH_NEIGHBORHOODS[0];
+  let nearestDistance = Number.POSITIVE_INFINITY;
+
+  for (const hood of PITTSBURGH_NEIGHBORHOODS) {
+    const d = milesBetween(point, hood.center);
+    if (d < nearestDistance) {
+      nearest = hood;
+      nearestDistance = d;
+    }
+  }
+
+  return nearest.name;
+}
+
+export function coordinateFromLocation(location: string): GeoPoint | null {
+  const normalized = location.toLowerCase();
+  const mapping = LOCATION_TO_COORDINATE.find((entry) => normalized.includes(entry.match));
+  return mapping?.point ?? null;
+}

--- a/Buyinz/package-lock.json
+++ b/Buyinz/package-lock.json
@@ -20,6 +20,7 @@
         "expo-image": "~3.0.11",
         "expo-image-picker": "~17.0.10",
         "expo-linking": "~8.0.11",
+        "expo-location": "~19.0.8",
         "expo-router": "~6.0.23",
         "expo-secure-store": "~15.0.8",
         "expo-splash-screen": "~31.0.13",
@@ -6278,6 +6279,15 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-location": {
+      "version": "19.0.8",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-19.0.8.tgz",
+      "integrity": "sha512-H/FI75VuJ1coodJbbMu82pf+Zjess8X8Xkiv9Bv58ZgPKS/2ztjC1YO1/XMcGz7+s9DrbLuMIw22dFuP4HqneA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {

--- a/Buyinz/package.json
+++ b/Buyinz/package.json
@@ -23,6 +23,7 @@
     "expo-image": "~3.0.11",
     "expo-image-picker": "~17.0.10",
     "expo-linking": "~8.0.11",
+    "expo-location": "~19.0.8",
     "expo-router": "~6.0.23",
     "expo-secure-store": "~15.0.8",
     "expo-splash-screen": "~31.0.13",

--- a/Buyinz/supabase/queries.ts
+++ b/Buyinz/supabase/queries.ts
@@ -1,9 +1,29 @@
 import { supabase } from './client';
 import type { Post, SalePost, ISOPost, Seller } from '@/data/mockData';
+import {
+  coordinateFromLocation,
+  DEFAULT_PITTSBURGH_COORDS,
+  milesBetween,
+  resolveNeighborhood,
+  type GeoPoint,
+} from '@/lib/discoveryLocation';
 import type { ListingDraft, ImageAsset } from '@/lib/listings';
 
 const DEFAULT_MOCK_USER_ID = '11111111-1111-1111-1111-111111111111';
 const IMAGE_BUCKET = 'listing-images';
+
+export { DEFAULT_PITTSBURGH_COORDS };
+export type { GeoPoint };
+
+export interface DiscoverySalePost extends SalePost {
+  neighborhoodTag: string;
+  distanceMiles: number;
+}
+
+export interface DiscoveryFeedResult {
+  neighborhood: string;
+  listings: DiscoverySalePost[];
+}
 
 function timeAgo(dateStr: string): string {
   const now = Date.now();
@@ -73,6 +93,51 @@ export async function fetchFeedPosts(): Promise<Post[]> {
 
   if (error) throw error;
   return (data ?? []).map(mapRowToPost);
+}
+
+export async function fetchDiscoveryFeed(options: {
+  userCoords: GeoPoint;
+  radiusMiles: number;
+}): Promise<DiscoveryFeedResult> {
+  const { userCoords, radiusMiles } = options;
+  const userNeighborhood = resolveNeighborhood(userCoords);
+  const feed = await fetchFeedPosts();
+
+  const salePosts = feed.filter((post): post is SalePost => post.type === 'sale');
+
+  const enriched = salePosts.map((post) => {
+    const postCoords = coordinateFromLocation(post.seller.location) ?? DEFAULT_PITTSBURGH_COORDS;
+    const neighborhoodTag = resolveNeighborhood(postCoords);
+    const distanceMiles = milesBetween(userCoords, postCoords);
+    return {
+      ...post,
+      neighborhoodTag,
+      distanceMiles,
+    } satisfies DiscoverySalePost;
+  });
+
+  const filtered =
+    radiusMiles <= 0
+      ? enriched.filter((post) => post.neighborhoodTag === userNeighborhood)
+      : enriched.filter((post) => post.distanceMiles <= radiusMiles);
+
+  const listings = (filtered.length > 0 ? filtered : enriched)
+    .slice()
+    .sort((a, b) => {
+      const aIsLocal = a.neighborhoodTag === userNeighborhood ? 1 : 0;
+      const bIsLocal = b.neighborhoodTag === userNeighborhood ? 1 : 0;
+
+      if (aIsLocal !== bIsLocal) return bIsLocal - aIsLocal;
+      if (Math.abs(a.distanceMiles - b.distanceMiles) > 0.05) {
+        return a.distanceMiles - b.distanceMiles;
+      }
+      return b.likes - a.likes;
+    });
+
+  return {
+    neighborhood: userNeighborhood,
+    listings,
+  };
 }
 
 async function uploadListingImages(images: ImageAsset[]): Promise<string[]> {


### PR DESCRIPTION
**Summary**
This PR implements  #3 User Story 2: Pittsburgh Discovery Feed on local-discovery by rebasing the web Explore experience into the mobile app and wiring in location-based discovery logic.

Included changes
Reworked mobile Explore tab UI to match web discovery patterns and app theming:
feed header with dynamic title: “Trending in [Neighborhood]”
radius expansion controls: Neighborhood / 5 mi / 10 mi / 20 mi
shelf/category chips, tag chips, search
listing cards showing neighborhood tag + distance

Added geospatial discovery behavior for mobile feed ranking/filtering:
neighborhood detection using point-in-polygon
neighborhood-first prioritization
radius-based filtering

Added GPS-driven refresh behavior:
initial foreground location lookup
watch position updates
refresh feed when movement is significant

**Context**

This addresses the local discovery experience for Pittsburgh buyers, with a focus on:

- immediate neighborhood relevance by default
- fast “expansion” into nearby areas
- visible locality context on each listing (neighborhood + distance)
- automatic adaptation when user location changes
The refactor also improves separation of concerns by moving geospatial/domain logic out of data-access code.

**Test Plan**

Functional checks
[fetchDiscoveryFeed] returns neighborhood and enriched sale posts ([neighborhoodTag],  [distanceMiles]
Point-in-polygon neighborhood resolution is used before fallback behavior.
Local neighborhood posts are prioritized in sort order.

Build/type checks
npx tsc --noEmit passes in mobile project.
App compiles and Explore tab renders without runtime errors.
