### PR TITLE
OUTDATED: Store profile and location

### DIFF
--- a/Buyinz/.cursor/settings.json
+++ b/Buyinz/.cursor/settings.json
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "supabase": {
+      "enabled": true
+    }
+  }
+}

--- a/Buyinz/app/create-listing.tsx
+++ b/Buyinz/app/create-listing.tsx
@@ -21,10 +21,21 @@ import { PhotoPicker } from '@/components/create/PhotoPicker';
 import {
   EMPTY_DRAFT,
   isDraftValid,
+  LISTING_CATEGORIES,
   submitListing,
-  type ListingDraft,
   type ImageAsset,
+  type ListingCategory,
+  type ListingDraft,
 } from '@/lib/listings';
+
+const CATEGORY_EMOJI: Record<ListingCategory, string> = {
+  Furniture: '🛋️',
+  Clothing: '👗',
+  Electronics: '📱',
+  Books: '📚',
+  Decor: '🪴',
+  Other: '📦',
+};
 
 export default function CreateListingScreen() {
   const router = useRouter();
@@ -78,6 +89,43 @@ export default function CreateListingScreen() {
             images={draft.images}
             onChange={(imgs: ImageAsset[]) => update('images', imgs)}
           />
+        </View>
+
+        <View style={styles.section}>
+          <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>Category</Text>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.categoryRow}
+          >
+            {LISTING_CATEGORIES.map((id) => {
+              const selected = draft.category === id;
+              return (
+                <Pressable
+                  key={id}
+                  onPress={() => update('category', id)}
+                  style={[
+                    styles.categoryChip,
+                    {
+                      backgroundColor: selected ? Brand.primary : colors.card,
+                      borderColor: selected ? Brand.primary : colors.border,
+                    },
+                  ]}
+                >
+                  <Text style={styles.categoryEmoji}>{CATEGORY_EMOJI[id]}</Text>
+                  <Text
+                    style={[
+                      styles.categoryChipText,
+                      { color: selected ? '#fff' : colors.text },
+                    ]}
+                    numberOfLines={1}
+                  >
+                    {id}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </ScrollView>
         </View>
 
         <View style={styles.section}>
@@ -171,6 +219,28 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
     letterSpacing: 0.5,
     marginBottom: 10,
+  },
+  categoryRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 2,
+  },
+  categoryChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+  },
+  categoryEmoji: {
+    fontSize: 16,
+  },
+  categoryChipText: {
+    fontSize: 14,
+    fontWeight: '600',
   },
   input: {
     fontSize: 16,

--- a/Buyinz/app/create-profile.tsx
+++ b/Buyinz/app/create-profile.tsx
@@ -2,12 +2,19 @@ import { Brand, Colors } from '@/constants/theme';
 import { useAuth } from '@/contexts/AuthContext';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import {
+  normalizeUsStateRegion,
+  validateUsStoreAddressFormat,
+} from '@/lib/addressValidation';
+import {
   authenticateWithGoogle,
   checkUsernameAvailable,
+  composeStoreAddressString,
   fetchBuyinzUserRowByAuthId,
+  geocodeAddressString,
   isProfileOnboardingComplete,
   normalizeUsername,
   saveProfile,
+  storeAddressPartsComplete,
   supabase,
   validateOnboardingSave,
 } from '@/lib/supabase';
@@ -42,7 +49,11 @@ WebBrowser.maybeCompleteAuthSession();
 
 type Phase = 'signIn' | 'onboarding';
 
+type OnboardingSubphase = 'chooseType' | 'form';
+
 type UsernameCheck = 'idle' | 'checking' | 'ok' | 'taken' | 'error';
+
+type AccountKind = 'user' | 'store';
 
 export default function CreateProfileScreen() {
   const router = useRouter();
@@ -57,14 +68,23 @@ export default function CreateProfileScreen() {
   const [phase, setPhase] = useState<Phase>('signIn');
   const [oauthEmail, setOauthEmail] = useState('');
 
+  const [onboardingSubphase, setOnboardingSubphase] =
+    useState<OnboardingSubphase>('chooseType');
+  const [accountKind, setAccountKind] = useState<AccountKind | null>(null);
+
   const [displayName, setDisplayName] = useState('');
   const [username, setUsername] = useState('');
   const [location, setLocation] = useState('');
+  const [addressLine1, setAddressLine1] = useState('');
+  const [city, setCity] = useState('');
+  const [region, setRegion] = useState('');
+  const [postalCode, setPostalCode] = useState('');
   const [bio, setBio] = useState('');
   const [avatarUrl, setAvatarUrl] = useState(DEFAULT_AVATAR);
 
   const [isLoading, setIsLoading] = useState(false);
   const [usernameCheck, setUsernameCheck] = useState<UsernameCheck>('idle');
+  const [showValidation, setShowValidation] = useState(false);
 
   useEffect(() => {
     if (phase !== 'onboarding') return;
@@ -85,10 +105,17 @@ export default function CreateProfileScreen() {
     const email = authUser.email ?? '';
     setOauthEmail(email);
     const meta = authUser.user_metadata;
+    setOnboardingSubphase('chooseType');
+    setAccountKind(null);
     setDisplayName('');
     setUsername('');
     setLocation('');
+    setAddressLine1('');
+    setCity('');
+    setRegion('');
+    setPostalCode('');
     setBio('');
+    setShowValidation(false);
     setAvatarUrl(
       (meta?.avatar_url as string) || DEFAULT_AVATAR,
     );
@@ -104,6 +131,7 @@ export default function CreateProfileScreen() {
         setUser({
           id: authUser.id,
           email,
+          account_type: row.account_type ?? 'user',
           display_name: row.display_name,
           username: row.username,
           location: row.location ?? '',
@@ -121,7 +149,7 @@ export default function CreateProfileScreen() {
   );
 
   useEffect(() => {
-    if (phase !== 'onboarding') {
+    if (phase !== 'onboarding' || onboardingSubphase !== 'form') {
       setUsernameCheck('idle');
       return;
     }
@@ -140,7 +168,27 @@ export default function CreateProfileScreen() {
       }
     }, 450);
     return () => clearTimeout(t);
-  }, [username, phase]);
+  }, [username, phase, onboardingSubphase]);
+
+  const switchAccountKind = (next: AccountKind) => {
+    if (accountKind === next) return;
+    if (next === 'user') {
+      setAddressLine1('');
+      setCity('');
+      setRegion('');
+      setPostalCode('');
+    } else {
+      setLocation('');
+    }
+    setAccountKind(next);
+    setShowValidation(false);
+  };
+
+  const pickAccountKind = (kind: AccountKind) => {
+    setAccountKind(kind);
+    setOnboardingSubphase('form');
+    setShowValidation(false);
+  };
 
   const handleImagePick = async () => {
     const result = await ImagePicker.launchImageLibraryAsync({
@@ -224,6 +272,7 @@ export default function CreateProfileScreen() {
   };
 
   const handleSave = async () => {
+    setShowValidation(true);
     setIsLoading(true);
     try {
       const {
@@ -239,16 +288,9 @@ export default function CreateProfileScreen() {
         throw new Error('Your account has no email; try signing in again.');
       }
 
-      const profilePayload = {
-        id: authUser.id,
-        display_name: displayName,
-        username,
-        location,
-        bio,
-        avatar_url: avatarUrl,
-      };
-
-      validateOnboardingSave(profilePayload);
+      if (!accountKind) {
+        throw new Error('Choose Shopper or Store.');
+      }
 
       const u = normalizeUsername(username);
       if (!u) {
@@ -259,15 +301,114 @@ export default function CreateProfileScreen() {
         throw new Error('This username is already taken.');
       }
 
+      if (accountKind === 'user') {
+        const profilePayload = {
+          id: authUser.id,
+          account_type: 'user' as const,
+          display_name: displayName,
+          username,
+          location,
+          bio,
+          avatar_url: avatarUrl,
+        };
+
+        validateOnboardingSave(profilePayload);
+
+        await saveProfile(profilePayload);
+        allowLeaveRef.current = true;
+        setUser({ ...profilePayload, email });
+
+        const preview = `${displayName}\n@${normalizeUsername(username)}\nZip: ${location.trim()}\n\nYou're set up to browse and list on Buyinz.`;
+
+        Alert.alert('Profile created', preview, [
+          {
+            text: 'OK',
+            onPress: () => router.replace('/(tabs)/profile'),
+          },
+        ]);
+        return;
+      }
+
+      const regionNorm = normalizeUsStateRegion(region);
+      const address_string = composeStoreAddressString({
+        address_line1: addressLine1.trim(),
+        city: city.trim(),
+        region: regionNorm,
+        postal_code: postalCode.trim(),
+      });
+
+      const profilePayloadBase = {
+        id: authUser.id,
+        account_type: 'store' as const,
+        display_name: displayName,
+        username,
+        location: postalCode.trim(),
+        bio,
+        avatar_url: avatarUrl,
+        address_line1: addressLine1.trim(),
+        city: city.trim(),
+        region: regionNorm,
+        postal_code: postalCode.trim(),
+        address_string,
+      };
+
+      if (!storeAddressPartsComplete(profilePayloadBase)) {
+        throw new Error(
+          'Enter street, city, state, and ZIP so we can find your store.',
+        );
+      }
+
+      const formatCheck = validateUsStoreAddressFormat({
+        address_line1: addressLine1,
+        city,
+        region,
+        postal_code: postalCode,
+      });
+      if (!formatCheck.ok) {
+        throw new Error(formatCheck.message);
+      }
+
+      const geo = await geocodeAddressString(address_string, {
+        expectedPostalCode: postalCode.trim(),
+        expectedRegion: regionNorm,
+      });
+
+      const profilePayload = {
+        ...profilePayloadBase,
+        latitude: geo.latitude,
+        longitude: geo.longitude,
+        formatted_address: geo.formatted_address ?? null,
+      };
+
+      validateOnboardingSave(profilePayload);
+
       await saveProfile(profilePayload);
       allowLeaveRef.current = true;
-      setUser({ ...profilePayload, email });
+      setUser({
+        ...profilePayload,
+        email,
+      });
 
-      Alert.alert(
-        'Success',
-        'Verification complete and Profile created successfully!',
-      );
-      router.replace('/(tabs)/profile');
+      const addrLine =
+        geo.formatted_address ??
+        composeStoreAddressString({
+          address_line1: addressLine1.trim(),
+          city: city.trim(),
+          region: regionNorm,
+          postal_code: postalCode.trim(),
+        });
+
+      let preview = `${displayName}\n@${normalizeUsername(username)}\n${addrLine}\n\nYour store location is saved for distance-based browsing.`;
+      if (geo.warnings?.length) {
+        preview += `\n\n${geo.warnings.join('\n\n')}`;
+      }
+
+      Alert.alert('Profile created', preview, [
+        {
+          text: 'OK',
+          onPress: () => router.replace('/(tabs)/profile'),
+        },
+      ]);
     } catch (error: unknown) {
       const message =
         error instanceof Error ? error.message : 'Could not save profile';
@@ -277,13 +418,34 @@ export default function CreateProfileScreen() {
     }
   };
 
-  const coreFilled =
+  const userCoreFilled =
     !!displayName.trim() &&
     !!normalizeUsername(username) &&
     !!location.trim();
 
+  const storeCoreFilled =
+    !!displayName.trim() &&
+    !!normalizeUsername(username) &&
+    validateUsStoreAddressFormat({
+      address_line1: addressLine1,
+      city,
+      region,
+      postal_code: postalCode,
+    }).ok;
+
+  const coreFilled =
+    accountKind === 'user'
+      ? userCoreFilled
+      : accountKind === 'store'
+        ? storeCoreFilled
+        : false;
+
   const saveDisabled =
-    isLoading || !coreFilled || usernameCheck !== 'ok';
+    isLoading ||
+    !coreFilled ||
+    usernameCheck !== 'ok' ||
+    onboardingSubphase !== 'form' ||
+    !accountKind;
 
   const headerTitle =
     phase === 'signIn' ? 'Sign in' : 'Complete your profile';
@@ -318,6 +480,9 @@ export default function CreateProfileScreen() {
     }
     return null;
   };
+
+  const fieldErr = (empty: boolean) =>
+    showValidation && empty ? styles.inputError : undefined;
 
   return (
     <KeyboardAvoidingView
@@ -386,6 +551,70 @@ export default function CreateProfileScreen() {
               )}
             </Pressable>
           </View>
+        ) : onboardingSubphase === 'chooseType' ? (
+          <View
+            style={[
+              styles.section,
+              { backgroundColor: scheme === 'light' ? '#f5f5f5' : '#1c1c1e' },
+            ]}
+          >
+            <Text style={[styles.sectionTitle, { color: colors.text }]}>
+              Join Buyinz as
+            </Text>
+            <Text
+              style={{
+                color: colors.text,
+                marginBottom: 16,
+                fontSize: 13,
+                opacity: 0.85,
+              }}
+            >
+              Choose how you will use the app. You can change this on the next
+              screen before saving.
+            </Text>
+            {oauthEmail ? (
+              <Text
+                style={{
+                  color: colors.text,
+                  marginBottom: 16,
+                  fontSize: 13,
+                  opacity: 0.85,
+                }}
+              >
+                Signed in as {oauthEmail}
+              </Text>
+            ) : null}
+
+            <Pressable
+              style={[styles.choiceBtn, { borderColor: colors.border }]}
+              onPress={() => pickAccountKind('user')}
+            >
+              <Ionicons name="person-outline" size={22} color={colors.text} />
+              <Text style={[styles.choiceBtnTitle, { color: colors.text }]}>
+                Shopper
+              </Text>
+              <Text
+                style={[styles.choiceBtnSub, { color: colors.tabIconDefault }]}
+              >
+                Browse and buy from local thrift listings
+              </Text>
+            </Pressable>
+
+            <Pressable
+              style={[styles.choiceBtn, { borderColor: colors.border }]}
+              onPress={() => pickAccountKind('store')}
+            >
+              <Ionicons name="storefront-outline" size={22} color={colors.text} />
+              <Text style={[styles.choiceBtnTitle, { color: colors.text }]}>
+                Thrift store
+              </Text>
+              <Text
+                style={[styles.choiceBtnSub, { color: colors.tabIconDefault }]}
+              >
+                List inventory and connect with local shoppers
+              </Text>
+            </Pressable>
+          </View>
         ) : (
           <View
             style={[
@@ -409,6 +638,52 @@ export default function CreateProfileScreen() {
               </Text>
             ) : null}
 
+            <View style={styles.segmentRow}>
+              <Pressable
+                style={[
+                  styles.segmentBtn,
+                  accountKind === 'user' && styles.segmentBtnActive,
+                  { borderColor: colors.border },
+                ]}
+                onPress={() => switchAccountKind('user')}
+              >
+                <Text
+                  style={[
+                    styles.segmentBtnText,
+                    { color: accountKind === 'user' ? '#fff' : colors.text },
+                  ]}
+                >
+                  Shopper
+                </Text>
+              </Pressable>
+              <Pressable
+                style={[
+                  styles.segmentBtn,
+                  accountKind === 'store' && styles.segmentBtnActive,
+                  { borderColor: colors.border },
+                ]}
+                onPress={() => switchAccountKind('store')}
+              >
+                <Text
+                  style={[
+                    styles.segmentBtnText,
+                    { color: accountKind === 'store' ? '#fff' : colors.text },
+                  ]}
+                >
+                  Store
+                </Text>
+              </Pressable>
+            </View>
+            <Text
+              style={[
+                styles.switchHint,
+                { color: colors.tabIconDefault },
+              ]}
+            >
+              Switching clears address fields that do not apply to the other
+              profile type.
+            </Text>
+
             <View style={styles.avatarContainer}>
               <Image
                 source={{ uri: avatarUrl }}
@@ -423,8 +698,13 @@ export default function CreateProfileScreen() {
               style={[
                 styles.input,
                 { color: colors.text, borderColor: colors.border },
+                fieldErr(!displayName.trim()),
               ]}
-              placeholder="Name (Required)"
+              placeholder={
+                accountKind === 'store'
+                  ? 'Business name (Required)'
+                  : 'Name (Required)'
+              }
               placeholderTextColor={colors.tabIconDefault}
               value={displayName}
               onChangeText={setDisplayName}
@@ -433,8 +713,9 @@ export default function CreateProfileScreen() {
               style={[
                 styles.input,
                 { color: colors.text, borderColor: colors.border },
+                fieldErr(!normalizeUsername(username)),
               ]}
-              placeholder="Username (Required)"
+              placeholder="Username / handle (Required)"
               placeholderTextColor={colors.tabIconDefault}
               value={username}
               onChangeText={setUsername}
@@ -442,17 +723,71 @@ export default function CreateProfileScreen() {
               autoCorrect={false}
             />
             {usernameHint()}
-            <TextInput
-              style={[
-                styles.input,
-                { color: colors.text, borderColor: colors.border },
-              ]}
-              placeholder="Zip Code (Required)"
-              placeholderTextColor={colors.tabIconDefault}
-              value={location}
-              onChangeText={setLocation}
-              keyboardType="numeric"
-            />
+
+            {accountKind === 'user' ? (
+              <TextInput
+                style={[
+                  styles.input,
+                  { color: colors.text, borderColor: colors.border },
+                  fieldErr(!location.trim()),
+                ]}
+                placeholder="Zip Code (Required)"
+                placeholderTextColor={colors.tabIconDefault}
+                value={location}
+                onChangeText={setLocation}
+                keyboardType="numeric"
+              />
+            ) : (
+              <>
+                <TextInput
+                  style={[
+                    styles.input,
+                    { color: colors.text, borderColor: colors.border },
+                    fieldErr(!addressLine1.trim()),
+                  ]}
+                  placeholder="Street address (Required)"
+                  placeholderTextColor={colors.tabIconDefault}
+                  value={addressLine1}
+                  onChangeText={setAddressLine1}
+                />
+                <TextInput
+                  style={[
+                    styles.input,
+                    { color: colors.text, borderColor: colors.border },
+                    fieldErr(!city.trim()),
+                  ]}
+                  placeholder="City (Required)"
+                  placeholderTextColor={colors.tabIconDefault}
+                  value={city}
+                  onChangeText={setCity}
+                />
+                <TextInput
+                  style={[
+                    styles.input,
+                    { color: colors.text, borderColor: colors.border },
+                    fieldErr(!region.trim()),
+                  ]}
+                  placeholder="State (2 letters, e.g. PA)"
+                  placeholderTextColor={colors.tabIconDefault}
+                  value={region}
+                  onChangeText={setRegion}
+                  autoCapitalize="characters"
+                />
+                <TextInput
+                  style={[
+                    styles.input,
+                    { color: colors.text, borderColor: colors.border },
+                    fieldErr(!postalCode.trim()),
+                  ]}
+                  placeholder="ZIP (5 digits or ZIP+4)"
+                  placeholderTextColor={colors.tabIconDefault}
+                  value={postalCode}
+                  onChangeText={setPostalCode}
+                  keyboardType="numeric"
+                />
+              </>
+            )}
+
             <TextInput
               style={[
                 styles.input,
@@ -539,6 +874,46 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontWeight: '600',
   },
+  choiceBtn: {
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 12,
+  },
+  choiceBtnTitle: {
+    fontSize: 17,
+    fontWeight: '700',
+    marginTop: 8,
+  },
+  choiceBtnSub: {
+    fontSize: 13,
+    marginTop: 4,
+  },
+  segmentRow: {
+    flexDirection: 'row',
+    gap: 10,
+    marginBottom: 8,
+  },
+  segmentBtn: {
+    flex: 1,
+    paddingVertical: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+    alignItems: 'center',
+  },
+  segmentBtnActive: {
+    backgroundColor: Brand.primary,
+    borderColor: Brand.primary,
+  },
+  segmentBtnText: {
+    fontWeight: '700',
+    fontSize: 14,
+  },
+  switchHint: {
+    fontSize: 12,
+    marginBottom: 16,
+    opacity: 0.9,
+  },
   avatarContainer: {
     alignItems: 'center',
     marginBottom: 20,
@@ -564,6 +939,9 @@ const styles = StyleSheet.create({
     padding: 12,
     marginBottom: 12,
     fontSize: 15,
+  },
+  inputError: {
+    borderColor: '#ef4444',
   },
   textArea: {
     height: 80,

--- a/Buyinz/app/edit-profile.tsx
+++ b/Buyinz/app/edit-profile.tsx
@@ -2,19 +2,12 @@ import { Brand, Colors } from '@/constants/theme';
 import { useAuth } from '@/contexts/AuthContext';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import {
-  normalizeUsStateRegion,
-  validateUsStoreAddressFormat,
-} from '@/lib/addressValidation';
-import {
   type AccountType,
   checkUsernameAvailable,
-  composeStoreAddressString,
   deleteProfileForCurrentUser,
   fetchBuyinzUserRowByAuthId,
-  geocodeAddressString,
   normalizeUsername,
   saveProfile,
-  storeAddressPartsComplete,
   supabase,
   validateProfileUpdate,
 } from '@/lib/supabase';
@@ -64,6 +57,9 @@ export default function EditProfileScreen() {
   const [deleting, setDeleting] = useState(false);
   const [usernameCheck, setUsernameCheck] = useState<UsernameCheck>('idle');
   const [hydrated, setHydrated] = useState(false);
+  /** Geocoder line from DB; shown read-only for stores. */
+  const [storeFormattedAddressLine, setStoreFormattedAddressLine] =
+    useState('');
 
   useEffect(() => {
     const uid = user?.id;
@@ -86,6 +82,7 @@ export default function EditProfileScreen() {
         setPostalCode(row?.postal_code ?? '');
         setBio(row?.bio ?? user.bio ?? '');
         setAvatarUrl(row?.avatar_url ?? user.avatar_url ?? DEFAULT_AVATAR);
+        setStoreFormattedAddressLine(row?.formatted_address ?? '');
       } finally {
         if (!cancelled) setHydrated(true);
       }
@@ -166,55 +163,27 @@ export default function EditProfileScreen() {
         return;
       }
 
-      const regionNorm = normalizeUsStateRegion(region);
-      const address_string = composeStoreAddressString({
-        address_line1: addressLine1.trim(),
-        city: city.trim(),
-        region: regionNorm,
-        postal_code: postalCode.trim(),
-      });
-
-      const baseStore = {
-        id: user.id,
-        account_type: 'store' as const,
-        display_name: displayName,
-        username,
-        location: postalCode.trim(),
-        bio,
-        avatar_url: avatarUrl,
-        address_line1: addressLine1.trim(),
-        city: city.trim(),
-        region: regionNorm,
-        postal_code: postalCode.trim(),
-        address_string,
-      };
-
-      if (!storeAddressPartsComplete(baseStore)) {
-        throw new Error(
-          'Enter street, city, state, and ZIP so we can find your store.',
-        );
+      const row = await fetchBuyinzUserRowByAuthId(user.id);
+      if (!row || row.account_type !== 'store') {
+        throw new Error('Could not load your store profile.');
       }
-
-      const formatCheck = validateUsStoreAddressFormat({
-        address_line1: addressLine1,
-        city,
-        region,
-        postal_code: postalCode,
-      });
-      if (!formatCheck.ok) {
-        throw new Error(formatCheck.message);
-      }
-
-      const geo = await geocodeAddressString(address_string, {
-        expectedPostalCode: postalCode.trim(),
-        expectedRegion: regionNorm,
-      });
 
       const profilePayload = {
-        ...baseStore,
-        latitude: geo.latitude,
-        longitude: geo.longitude,
-        formatted_address: geo.formatted_address ?? null,
+        id: user.id,
+        account_type: 'store' as const,
+        display_name: displayName.trim(),
+        username,
+        bio,
+        avatar_url: row.avatar_url ?? undefined,
+        location: row.location ?? '',
+        address_line1: row.address_line1,
+        city: row.city,
+        region: row.region,
+        postal_code: row.postal_code,
+        address_string: row.address_string,
+        latitude: row.latitude,
+        longitude: row.longitude,
+        formatted_address: row.formatted_address,
       };
 
       validateProfileUpdate(profilePayload);
@@ -225,11 +194,7 @@ export default function EditProfileScreen() {
         email: user.email,
       });
 
-      let successMsg = 'Profile updated.';
-      if (geo.warnings?.length) {
-        successMsg += `\n\n${geo.warnings.join('\n\n')}`;
-      }
-      Alert.alert('Success', successMsg);
+      Alert.alert('Success', 'Profile updated.');
       router.back();
     } catch (error: unknown) {
       const message =
@@ -292,17 +257,15 @@ export default function EditProfileScreen() {
     !!location.trim();
 
   const storeCoreFilled =
-    !!displayName.trim() &&
-    !!normalizeUsername(username) &&
-    validateUsStoreAddressFormat({
-      address_line1: addressLine1,
-      city,
-      region,
-      postal_code: postalCode,
-    }).ok;
+    !!displayName.trim() && !!normalizeUsername(username);
 
   const coreFilled =
     accountType === 'user' ? userCoreFilled : storeCoreFilled;
+
+  const storeAddressReadOnly = [addressLine1, city, region, postalCode]
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .join(', ');
 
   const saveDisabled =
     isLoading || deleting || !coreFilled || usernameCheck !== 'ok';
@@ -388,9 +351,17 @@ export default function EditProfileScreen() {
               source={{ uri: avatarUrl }}
               style={[styles.avatar, { borderColor: colors.border }]}
             />
-            <Pressable style={styles.changePhotoBtn} onPress={handleImagePick}>
-              <Text style={styles.changePhotoText}>Change Profile Photo</Text>
-            </Pressable>
+            {accountType === 'user' ? (
+              <Pressable style={styles.changePhotoBtn} onPress={handleImagePick}>
+                <Text style={styles.changePhotoText}>Change Profile Photo</Text>
+              </Pressable>
+            ) : (
+              <Text
+                style={[styles.readOnlyHint, { color: colors.tabIconDefault }]}
+              >
+                Profile photo
+              </Text>
+            )}
           </View>
 
           <TextInput
@@ -433,50 +404,29 @@ export default function EditProfileScreen() {
               keyboardType="numeric"
             />
           ) : (
-            <>
-              <TextInput
+            <View style={{ marginBottom: 12 }}>
+              <Text
                 style={[
-                  styles.input,
-                  { color: colors.text, borderColor: colors.border },
+                  styles.readOnlySectionLabel,
+                  { color: colors.textSecondary },
                 ]}
-                placeholder="Street address (Required)"
-                placeholderTextColor={colors.tabIconDefault}
-                value={addressLine1}
-                onChangeText={setAddressLine1}
-              />
-              <TextInput
-                style={[
-                  styles.input,
-                  { color: colors.text, borderColor: colors.border },
-                ]}
-                placeholder="City (Required)"
-                placeholderTextColor={colors.tabIconDefault}
-                value={city}
-                onChangeText={setCity}
-              />
-              <TextInput
-                style={[
-                  styles.input,
-                  { color: colors.text, borderColor: colors.border },
-                ]}
-                placeholder="State (2 letters, e.g. PA)"
-                placeholderTextColor={colors.tabIconDefault}
-                value={region}
-                onChangeText={setRegion}
-                autoCapitalize="characters"
-              />
-              <TextInput
-                style={[
-                  styles.input,
-                  { color: colors.text, borderColor: colors.border },
-                ]}
-                placeholder="ZIP (5 digits or ZIP+4)"
-                placeholderTextColor={colors.tabIconDefault}
-                value={postalCode}
-                onChangeText={setPostalCode}
-                keyboardType="numeric"
-              />
-            </>
+              >
+                Store location
+              </Text>
+              <Text
+                style={[styles.readOnlyAddress, { color: colors.text }]}
+              >
+                {storeFormattedAddressLine.trim() ||
+                  storeAddressReadOnly ||
+                  '—'}
+              </Text>
+              <Text
+                style={[styles.readOnlyHint, { color: colors.tabIconDefault }]}
+              >
+                Address was saved when you created your store and can’t be
+                edited here.
+              </Text>
+            </View>
           )}
           <TextInput
             style={[
@@ -601,6 +551,22 @@ const styles = StyleSheet.create({
     color: Brand.primary,
     fontWeight: '600',
     fontSize: 14,
+  },
+  readOnlySectionLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 8,
+  },
+  readOnlyAddress: {
+    fontSize: 15,
+    lineHeight: 22,
+    marginBottom: 8,
+  },
+  readOnlyHint: {
+    fontSize: 13,
+    lineHeight: 18,
   },
   input: {
     borderWidth: 1,

--- a/Buyinz/app/edit-profile.tsx
+++ b/Buyinz/app/edit-profile.tsx
@@ -2,11 +2,19 @@ import { Brand, Colors } from '@/constants/theme';
 import { useAuth } from '@/contexts/AuthContext';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import {
+  normalizeUsStateRegion,
+  validateUsStoreAddressFormat,
+} from '@/lib/addressValidation';
+import {
+  type AccountType,
   checkUsernameAvailable,
+  composeStoreAddressString,
   deleteProfileForCurrentUser,
   fetchBuyinzUserRowByAuthId,
+  geocodeAddressString,
   normalizeUsername,
   saveProfile,
+  storeAddressPartsComplete,
   supabase,
   validateProfileUpdate,
 } from '@/lib/supabase';
@@ -41,9 +49,14 @@ export default function EditProfileScreen() {
   const insets = useSafeAreaInsets();
   const { user, setUser } = useAuth();
 
+  const [accountType, setAccountType] = useState<AccountType>('user');
   const [displayName, setDisplayName] = useState('');
   const [username, setUsername] = useState('');
   const [location, setLocation] = useState('');
+  const [addressLine1, setAddressLine1] = useState('');
+  const [city, setCity] = useState('');
+  const [region, setRegion] = useState('');
+  const [postalCode, setPostalCode] = useState('');
   const [bio, setBio] = useState('');
   const [avatarUrl, setAvatarUrl] = useState(DEFAULT_AVATAR);
 
@@ -63,9 +76,14 @@ export default function EditProfileScreen() {
       try {
         const row = await fetchBuyinzUserRowByAuthId(uid);
         if (cancelled) return;
+        setAccountType(row?.account_type ?? user.account_type ?? 'user');
         setDisplayName(row?.display_name ?? user.display_name);
         setUsername(row?.username ?? user.username);
         setLocation(row?.location ?? user.location);
+        setAddressLine1(row?.address_line1 ?? '');
+        setCity(row?.city ?? '');
+        setRegion(row?.region ?? '');
+        setPostalCode(row?.postal_code ?? '');
         setBio(row?.bio ?? user.bio ?? '');
         setAvatarUrl(row?.avatar_url ?? user.avatar_url ?? DEFAULT_AVATAR);
       } finally {
@@ -113,17 +131,6 @@ export default function EditProfileScreen() {
     if (!user?.id) return;
     setIsLoading(true);
     try {
-      const profilePayload = {
-        id: user.id,
-        display_name: displayName,
-        username,
-        location,
-        bio,
-        avatar_url: avatarUrl,
-      };
-
-      validateProfileUpdate(profilePayload);
-
       const u = normalizeUsername(username);
       if (!u) {
         throw new Error('Please choose a username.');
@@ -135,13 +142,94 @@ export default function EditProfileScreen() {
         throw new Error('This username is already taken.');
       }
 
+      if (accountType === 'user') {
+        const profilePayload = {
+          id: user.id,
+          account_type: 'user' as const,
+          display_name: displayName,
+          username,
+          location,
+          bio,
+          avatar_url: avatarUrl,
+        };
+
+        validateProfileUpdate(profilePayload);
+
+        await saveProfile(profilePayload);
+        setUser({
+          ...profilePayload,
+          email: user.email,
+        });
+
+        Alert.alert('Success', 'Profile updated.');
+        router.back();
+        return;
+      }
+
+      const regionNorm = normalizeUsStateRegion(region);
+      const address_string = composeStoreAddressString({
+        address_line1: addressLine1.trim(),
+        city: city.trim(),
+        region: regionNorm,
+        postal_code: postalCode.trim(),
+      });
+
+      const baseStore = {
+        id: user.id,
+        account_type: 'store' as const,
+        display_name: displayName,
+        username,
+        location: postalCode.trim(),
+        bio,
+        avatar_url: avatarUrl,
+        address_line1: addressLine1.trim(),
+        city: city.trim(),
+        region: regionNorm,
+        postal_code: postalCode.trim(),
+        address_string,
+      };
+
+      if (!storeAddressPartsComplete(baseStore)) {
+        throw new Error(
+          'Enter street, city, state, and ZIP so we can find your store.',
+        );
+      }
+
+      const formatCheck = validateUsStoreAddressFormat({
+        address_line1: addressLine1,
+        city,
+        region,
+        postal_code: postalCode,
+      });
+      if (!formatCheck.ok) {
+        throw new Error(formatCheck.message);
+      }
+
+      const geo = await geocodeAddressString(address_string, {
+        expectedPostalCode: postalCode.trim(),
+        expectedRegion: regionNorm,
+      });
+
+      const profilePayload = {
+        ...baseStore,
+        latitude: geo.latitude,
+        longitude: geo.longitude,
+        formatted_address: geo.formatted_address ?? null,
+      };
+
+      validateProfileUpdate(profilePayload);
+
       await saveProfile(profilePayload);
       setUser({
         ...profilePayload,
         email: user.email,
       });
 
-      Alert.alert('Success', 'Profile updated.');
+      let successMsg = 'Profile updated.';
+      if (geo.warnings?.length) {
+        successMsg += `\n\n${geo.warnings.join('\n\n')}`;
+      }
+      Alert.alert('Success', successMsg);
       router.back();
     } catch (error: unknown) {
       const message =
@@ -198,10 +286,23 @@ export default function EditProfileScreen() {
     );
   };
 
-  const coreFilled =
+  const userCoreFilled =
     !!displayName.trim() &&
     !!normalizeUsername(username) &&
     !!location.trim();
+
+  const storeCoreFilled =
+    !!displayName.trim() &&
+    !!normalizeUsername(username) &&
+    validateUsStoreAddressFormat({
+      address_line1: addressLine1,
+      city,
+      region,
+      postal_code: postalCode,
+    }).ok;
+
+  const coreFilled =
+    accountType === 'user' ? userCoreFilled : storeCoreFilled;
 
   const saveDisabled =
     isLoading || deleting || !coreFilled || usernameCheck !== 'ok';
@@ -297,7 +398,11 @@ export default function EditProfileScreen() {
               styles.input,
               { color: colors.text, borderColor: colors.border },
             ]}
-            placeholder="Name (Required)"
+            placeholder={
+              accountType === 'store'
+                ? 'Business name (Required)'
+                : 'Name (Required)'
+            }
             placeholderTextColor={colors.tabIconDefault}
             value={displayName}
             onChangeText={setDisplayName}
@@ -315,17 +420,64 @@ export default function EditProfileScreen() {
             autoCorrect={false}
           />
           {usernameHint()}
-          <TextInput
-            style={[
-              styles.input,
-              { color: colors.text, borderColor: colors.border },
-            ]}
-            placeholder="Zip Code (Required)"
-            placeholderTextColor={colors.tabIconDefault}
-            value={location}
-            onChangeText={setLocation}
-            keyboardType="numeric"
-          />
+          {accountType === 'user' ? (
+            <TextInput
+              style={[
+                styles.input,
+                { color: colors.text, borderColor: colors.border },
+              ]}
+              placeholder="Zip Code (Required)"
+              placeholderTextColor={colors.tabIconDefault}
+              value={location}
+              onChangeText={setLocation}
+              keyboardType="numeric"
+            />
+          ) : (
+            <>
+              <TextInput
+                style={[
+                  styles.input,
+                  { color: colors.text, borderColor: colors.border },
+                ]}
+                placeholder="Street address (Required)"
+                placeholderTextColor={colors.tabIconDefault}
+                value={addressLine1}
+                onChangeText={setAddressLine1}
+              />
+              <TextInput
+                style={[
+                  styles.input,
+                  { color: colors.text, borderColor: colors.border },
+                ]}
+                placeholder="City (Required)"
+                placeholderTextColor={colors.tabIconDefault}
+                value={city}
+                onChangeText={setCity}
+              />
+              <TextInput
+                style={[
+                  styles.input,
+                  { color: colors.text, borderColor: colors.border },
+                ]}
+                placeholder="State (2 letters, e.g. PA)"
+                placeholderTextColor={colors.tabIconDefault}
+                value={region}
+                onChangeText={setRegion}
+                autoCapitalize="characters"
+              />
+              <TextInput
+                style={[
+                  styles.input,
+                  { color: colors.text, borderColor: colors.border },
+                ]}
+                placeholder="ZIP (5 digits or ZIP+4)"
+                placeholderTextColor={colors.tabIconDefault}
+                value={postalCode}
+                onChangeText={setPostalCode}
+                keyboardType="numeric"
+              />
+            </>
+          )}
           <TextInput
             style={[
               styles.input,

--- a/Buyinz/contexts/AuthContext.tsx
+++ b/Buyinz/contexts/AuthContext.tsx
@@ -1,7 +1,10 @@
 import React, { createContext, useState, useContext } from 'react';
+import type { AccountType } from '@/lib/supabase';
 
 export type User = {
   id?: string;
+  /** Defaults to shopper when omitted (e.g. older in-memory sessions). */
+  account_type?: AccountType;
   display_name: string;
   username: string;
   location: string;

--- a/Buyinz/lib/addressValidation.ts
+++ b/Buyinz/lib/addressValidation.ts
@@ -1,0 +1,83 @@
+/** US-oriented checks for store street address fields (client-side; no network). */
+
+const MAX_STREET_LEN = 120;
+const MAX_CITY_LEN = 80;
+const MIN_CITY_LEN = 2;
+
+/** US ZIP: 5 digits, optional hyphen + 4 extension. */
+const US_ZIP_REGEX = /^\d{5}(-\d{4})?$/;
+
+/** Two-letter US state / territory code (user input). */
+const US_STATE_REGEX = /^[A-Za-z]{2}$/;
+
+/** Normalize to first 5 digits for comparison with geocoder results. */
+export function normalizeUsZipToFiveDigits(input: string): string {
+  const digits = input.replace(/\D/g, '');
+  return digits.length >= 5 ? digits.slice(0, 5) : digits;
+}
+
+export function isValidUsZipFormat(input: string): boolean {
+  const t = input.trim();
+  if (!t) return false;
+  return US_ZIP_REGEX.test(t);
+}
+
+/** Uppercase 2-letter state/region code. */
+export function normalizeUsStateRegion(input: string): string {
+  return input.trim().toUpperCase().slice(0, 2);
+}
+
+export function isValidUsStateCode(input: string): boolean {
+  return US_STATE_REGEX.test(input.trim());
+}
+
+export type StoreAddressFieldInput = {
+  address_line1: string;
+  city: string;
+  region: string;
+  postal_code: string;
+};
+
+/**
+ * Validates format before calling geocode. Does not prove deliverability.
+ */
+export function validateUsStoreAddressFormat(
+  parts: StoreAddressFieldInput,
+): { ok: true } | { ok: false; message: string } {
+  const street = parts.address_line1.trim();
+  if (!street) {
+    return { ok: false, message: 'Street address is required.' };
+  }
+  if (street.length > MAX_STREET_LEN) {
+    return { ok: false, message: 'Street address is too long.' };
+  }
+
+  const city = parts.city.trim();
+  if (!city || city.length < MIN_CITY_LEN) {
+    return { ok: false, message: 'City is required.' };
+  }
+  if (city.length > MAX_CITY_LEN) {
+    return { ok: false, message: 'City name is too long.' };
+  }
+
+  const regionRaw = parts.region.trim();
+  if (!regionRaw) {
+    return { ok: false, message: 'State or region is required.' };
+  }
+  if (!isValidUsStateCode(regionRaw)) {
+    return {
+      ok: false,
+      message: 'Use a 2-letter state code (e.g. PA for Pennsylvania).',
+    };
+  }
+
+  const zip = parts.postal_code.trim();
+  if (!isValidUsZipFormat(zip)) {
+    return {
+      ok: false,
+      message: 'Enter a valid U.S. ZIP code (5 digits, optional +4).',
+    };
+  }
+
+  return { ok: true };
+}

--- a/Buyinz/lib/listings.ts
+++ b/Buyinz/lib/listings.ts
@@ -1,5 +1,17 @@
 import { insertPost } from '@/supabase/queries';
 
+/** Must match `posts.category` and Explore shelf filters (excluding All). */
+export const LISTING_CATEGORIES = [
+  'Furniture',
+  'Clothing',
+  'Electronics',
+  'Books',
+  'Decor',
+  'Other',
+] as const;
+
+export type ListingCategory = (typeof LISTING_CATEGORIES)[number];
+
 export interface ImageAsset {
   uri: string;
   width: number;
@@ -10,12 +22,14 @@ export interface ListingDraft {
   images: ImageAsset[];
   title: string;
   price: string;
+  category: ListingCategory;
 }
 
 export const EMPTY_DRAFT: ListingDraft = {
   images: [],
   title: '',
   price: '',
+  category: 'Other',
 };
 
 export const MAX_PHOTOS = 5;

--- a/Buyinz/lib/supabase.ts
+++ b/Buyinz/lib/supabase.ts
@@ -4,14 +4,26 @@ import { supabase } from '@/supabase/client';
 /** Re-export the shared client (SecureStore session) — same instance as @/supabase/queries. */
 export { supabase };
 
+export type AccountType = 'user' | 'store';
+
 export interface UserProfile {
   id?: string;
+  account_type?: AccountType;
   display_name: string;
   username: string;
+  /** Zip code for user accounts; for stores mirrors `postal_code` for existing UI. */
   location: string;
   bio?: string;
   avatar_url?: string;
   isVerified?: boolean;
+  address_line1?: string | null;
+  city?: string | null;
+  region?: string | null;
+  postal_code?: string | null;
+  address_string?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  formatted_address?: string | null;
 }
 
 /** Name, username, zip — bio optional (onboarding + main app entry). */
@@ -26,13 +38,69 @@ export function profileCoreComplete(profile: {
   return !!(dn && un && loc);
 }
 
+export function storeAddressPartsComplete(profile: {
+  address_line1?: string | null;
+  city?: string | null;
+  region?: string | null;
+  postal_code?: string | null;
+}): boolean {
+  return !!(
+    profile.address_line1?.trim() &&
+    profile.city?.trim() &&
+    profile.region?.trim() &&
+    profile.postal_code?.trim()
+  );
+}
+
+export function composeStoreAddressString(parts: {
+  address_line1: string;
+  city: string;
+  region: string;
+  postal_code: string;
+}): string {
+  return [parts.address_line1, parts.city, parts.region, parts.postal_code]
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .join(', ');
+}
+
+function storeProfileCoreComplete(profile: {
+  display_name?: string | null;
+  username?: string | null;
+  address_line1?: string | null;
+  city?: string | null;
+  region?: string | null;
+  postal_code?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+}): boolean {
+  return (
+    !!profile.display_name?.trim() &&
+    !!profile.username?.trim() &&
+    storeAddressPartsComplete(profile) &&
+    typeof profile.latitude === 'number' &&
+    typeof profile.longitude === 'number'
+  );
+}
+
 /** Row qualifies as a returning user: can skip onboarding (bio optional). */
 export function isProfileOnboardingComplete(profile: {
+  account_type?: AccountType | null;
   display_name?: string | null;
   username?: string | null;
   location?: string | null;
   bio?: string | null;
+  address_line1?: string | null;
+  city?: string | null;
+  region?: string | null;
+  postal_code?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
 }): boolean {
+  const t = profile.account_type ?? 'user';
+  if (t === 'store') {
+    return storeProfileCoreComplete(profile);
+  }
   return profileCoreComplete(profile);
 }
 
@@ -44,12 +112,21 @@ export function normalizeUsername(username: string): string {
 }
 
 export function validateOnboardingSave(profile: UserProfile): void {
+  const t = profile.account_type ?? 'user';
+  if (t === 'store') {
+    if (!storeProfileCoreComplete(profile)) {
+      throw new Error(
+        'Missing mandatory fields: business name, handle, full address, or location could not be verified.',
+      );
+    }
+    return;
+  }
   if (!profileCoreComplete(profile)) {
     throw new Error('Missing mandatory fields: Name, Username, or Zip Code');
   }
 }
 
-/** Edit profile: same required core fields; bio optional. */
+/** Edit profile: same required core fields per account type; bio optional. */
 export function validateProfileUpdate(profile: UserProfile): void {
   validateOnboardingSave(profile);
 }
@@ -59,13 +136,43 @@ export function validateProfileForSave(profile: UserProfile): void {
 }
 
 export function buildUsersUpsertPayload(profile: UserProfile) {
-  return {
+  const type = profile.account_type ?? 'user';
+  const base = {
     id: profile.id,
+    account_type: type,
     display_name: profile.display_name.trim(),
     username: normalizeUsername(profile.username),
-    location: profile.location.trim(),
-    bio: profile.bio?.trim() || undefined,
+    bio: profile.bio?.trim() || null,
     avatar_url: profile.avatar_url,
+  };
+
+  if (type === 'user') {
+    return {
+      ...base,
+      location: profile.location.trim(),
+      address_line1: null,
+      city: null,
+      region: null,
+      postal_code: null,
+      address_string: null,
+      latitude: null,
+      longitude: null,
+      formatted_address: null,
+    };
+  }
+
+  const postal = profile.postal_code?.trim() ?? '';
+  return {
+    ...base,
+    location: postal,
+    address_line1: profile.address_line1?.trim() ?? null,
+    city: profile.city?.trim() ?? null,
+    region: profile.region?.trim() ?? null,
+    postal_code: postal || null,
+    address_string: profile.address_string?.trim() ?? null,
+    latitude: profile.latitude ?? null,
+    longitude: profile.longitude ?? null,
+    formatted_address: profile.formatted_address?.trim() ?? null,
   };
 }
 
@@ -119,6 +226,104 @@ export async function saveProfile(profile: UserProfile) {
   return data;
 }
 
+export type GeocodeResult = {
+  latitude: number;
+  longitude: number;
+  formatted_address?: string;
+  /** Non-blocking notices from geocoder (e.g. partial match). */
+  warnings?: string[];
+};
+
+/** When set, Edge Function verifies ZIP/state against Google address_components. */
+export type GeocodeOptions = {
+  expectedPostalCode: string;
+  expectedRegion: string;
+};
+
+async function messageFromFunctionsError(
+  error: unknown,
+  response?: Response,
+): Promise<string> {
+  const base =
+    error instanceof Error ? error.message : 'Geocoding failed.';
+  const res =
+    response ??
+    (error as { context?: Response }).context;
+  if (res && typeof res.json === 'function') {
+    try {
+      const json = (await res.clone().json()) as {
+        error?: string;
+        message?: string;
+      };
+      if (json?.error && typeof json.error === 'string') return json.error;
+      if (json?.message && typeof json.message === 'string') return json.message;
+    } catch {
+      /* ignore */
+    }
+  }
+  return base;
+}
+
+/** Calls Edge Function `geocode-address` (Google Geocoding via server secret). */
+export async function geocodeAddressString(
+  address: string,
+  options?: GeocodeOptions,
+): Promise<GeocodeResult> {
+  const trimmed = address.trim();
+  if (!trimmed) {
+    throw new Error('Address is required for geocoding.');
+  }
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) {
+    throw new Error('Sign in again to verify your address.');
+  }
+
+  const { data, error, response: fnResponse } = await supabase.functions.invoke<
+    GeocodeResult & { error?: string; warnings?: string[] }
+  >('geocode-address', {
+    body: {
+      address: trimmed,
+      ...(options
+        ? {
+            expected_postal_code: options.expectedPostalCode,
+            expected_region: options.expectedRegion,
+          }
+        : {}),
+    },
+    headers: {
+      Authorization: `Bearer ${session.access_token}`,
+    },
+  });
+
+  if (error) {
+    const msg = await messageFromFunctionsError(error, fnResponse);
+    throw new Error(msg);
+  }
+
+  const payload = data as GeocodeResult & { error?: string } | null;
+  if (payload && typeof payload === 'object' && 'error' in payload && payload.error) {
+    throw new Error(String(payload.error));
+  }
+
+  if (
+    !payload ||
+    typeof payload.latitude !== 'number' ||
+    typeof payload.longitude !== 'number'
+  ) {
+    throw new Error('Invalid response from geocoding service.');
+  }
+
+  return {
+    latitude: payload.latitude,
+    longitude: payload.longitude,
+    formatted_address: payload.formatted_address,
+    warnings: Array.isArray(payload.warnings) ? payload.warnings : undefined,
+  };
+}
+
 export async function authenticate(email?: string) {
   validateEmailForAuth(email);
 
@@ -167,13 +372,25 @@ export type BuyinzUsersRow = {
   location: string | null;
   bio: string | null;
   avatar_url: string | null;
+  account_type: AccountType;
+  address_line1: string | null;
+  city: string | null;
+  region: string | null;
+  postal_code: string | null;
+  address_string: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  formatted_address: string | null;
 };
+
+const BUYINZ_USER_ROW_SELECT =
+  'id, display_name, username, location, bio, avatar_url, account_type, address_line1, city, region, postal_code, address_string, latitude, longitude, formatted_address';
 
 /** Load `public.users` for the authenticated user id (e.g. after OAuth). */
 export async function fetchBuyinzUserRowByAuthId(userId: string): Promise<BuyinzUsersRow | null> {
   const { data, error } = await supabase
     .from('users')
-    .select('id, display_name, username, location, bio, avatar_url')
+    .select(BUYINZ_USER_ROW_SELECT)
     .eq('id', userId)
     .maybeSingle();
 

--- a/Buyinz/package-lock.json
+++ b/Buyinz/package-lock.json
@@ -54,6 +54,7 @@
         "eslint-config-expo": "~10.0.0",
         "jest": "^30.3.0",
         "jest-expo": "~54.0.17",
+        "supabase": "^2.92.1",
         "ts-jest": "^29.4.6",
         "ts-node": "^10.9.2",
         "typescript": "~5.9.2"
@@ -6825,6 +6826,59 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/bin-links": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-6.0.0.tgz",
+      "integrity": "sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cmd-shim": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "read-cmd-shim": "^6.0.0",
+        "write-file-atomic": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/bin-links/node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/bin-links/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/bin-links/node_modules/write-file-atomic": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -7250,6 +7304,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cmd-shim": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
+      "integrity": "sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/co": {
@@ -8144,6 +8208,16 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/data-urls": {
       "version": "3.0.2",
@@ -10501,6 +10575,30 @@
         "asap": "~2.0.3"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -10679,6 +10777,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/freeport-async": {
@@ -17772,6 +17883,27 @@
       "integrity": "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==",
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -17852,6 +17984,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
+      "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm-package-arg": {
@@ -19328,6 +19470,16 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/read-cmd-shim": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-6.0.0.tgz",
+      "integrity": "sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -20503,6 +20655,69 @@
         "node": ">= 6"
       }
     },
+    "node_modules/supabase": {
+      "version": "2.92.1",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.92.1.tgz",
+      "integrity": "sha512-BB3olR2glhrE0YGDhq0vknJdrwjROaIHgiC/OZc94eLbBHnsJ3szKeRZkcF9dxRgxuq6QWdxCrn5m14lfu9tug==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bin-links": "^6.0.0",
+        "https-proxy-agent": "^9.0.0",
+        "node-fetch": "^3.3.2",
+        "tar": "7.5.13"
+      },
+      "bin": {
+        "supabase": "bin/supabase"
+      },
+      "engines": {
+        "npm": ">=8"
+      }
+    },
+    "node_modules/supabase/node_modules/agent-base": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/supabase/node_modules/https-proxy-agent": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.0.0.tgz",
+      "integrity": "sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/supabase/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -21657,6 +21872,16 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/Buyinz/package.json
+++ b/Buyinz/package.json
@@ -61,6 +61,7 @@
     "eslint-config-expo": "~10.0.0",
     "jest": "^30.3.0",
     "jest-expo": "~54.0.17",
+    "supabase": "^2.92.1",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",
     "typescript": "~5.9.2"

--- a/Buyinz/supabase/.gitignore
+++ b/Buyinz/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/Buyinz/supabase/config.toml
+++ b/Buyinz/supabase/config.toml
@@ -1,0 +1,411 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "Buyinz"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+# This feature is only available on the hosted platform.
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+# ES256 user access tokens (ECC JWT signing keys) fail gateway verification with
+# UNAUTHORIZED_UNSUPPORTED_TOKEN_ALGORITHM — auth still enforced in function code.
+[functions.geocode-address]
+verify_jwt = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# [experimental.pgdelta]
+# When enabled, pg-delta becomes the active engine for supported schema flows.
+# enabled = false
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/Buyinz/supabase/functions/geocode-address/index.ts
+++ b/Buyinz/supabase/functions/geocode-address/index.ts
@@ -1,0 +1,297 @@
+/**
+ * Geocodes a postal address via Google Geocoding API.
+ * Set secret GOOGLE_MAPS_GEOCODING_API_KEY in the Supabase project (Edge Function secrets).
+ *
+ * Deploy with gateway JWT verification OFF (`verify_jwt = false` in config.toml or
+ * `supabase functions deploy geocode-address --no-verify-jwt`). User sessions use ES256;
+ * the Edge API gateway may reject them with UNAUTHORIZED_UNSUPPORTED_TOKEN_ALGORITHM before
+ * this code runs. Authorization is enforced below via supabase.auth.getUser().
+ */
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
+
+const corsHeaders: Record<string, string> = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+};
+
+function zipToFiveDigits(s: string): string {
+  const d = s.replace(/\D/g, "");
+  return d.length >= 5 ? d.slice(0, 5) : d;
+}
+
+function normalizeStateTwoLetter(s: string): string {
+  return s.trim().toUpperCase().slice(0, 2);
+}
+
+type AddressComponent = {
+  long_name: string;
+  short_name: string;
+  types: string[];
+};
+
+function extractPostalAndState(
+  components: AddressComponent[] | undefined,
+): { postalDigits: string; state: string } {
+  let postalLong = "";
+  let state = "";
+  for (const c of components ?? []) {
+    if (c.types.includes("postal_code")) {
+      postalLong = c.long_name || c.short_name || "";
+    }
+    if (c.types.includes("administrative_area_level_1")) {
+      state = c.short_name || "";
+    }
+  }
+  return { postalDigits: zipToFiveDigits(postalLong), state: state.trim() };
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    if (req.method !== "POST") {
+      return new Response(JSON.stringify({ error: "Method not allowed" }), {
+        status: 405,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
+    if (!supabaseUrl || !supabaseAnonKey) {
+      return new Response(JSON.stringify({ error: "Server misconfigured" }), {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader?.startsWith("Bearer ")) {
+      return new Response(
+        JSON.stringify({ error: "Missing or invalid authorization" }),
+        {
+          status: 401,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+      global: { headers: { Authorization: authHeader } },
+    });
+
+    const { data: userData, error: userError } = await supabase.auth.getUser();
+    if (userError || !userData.user) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    let body: {
+      address?: string;
+      expected_postal_code?: string;
+      expected_region?: string;
+    };
+    try {
+      body = await req.json();
+    } catch {
+      return new Response(JSON.stringify({ error: "Invalid JSON body" }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const address = typeof body.address === "string" ? body.address.trim() : "";
+    if (!address) {
+      return new Response(JSON.stringify({ error: "Address is required" }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const expectZip =
+      typeof body.expected_postal_code === "string"
+        ? body.expected_postal_code.trim()
+        : "";
+    const expectRegion =
+      typeof body.expected_region === "string"
+        ? body.expected_region.trim()
+        : "";
+    const doComponentCheck = !!(expectZip && expectRegion);
+
+    const apiKey = Deno.env.get("GOOGLE_MAPS_GEOCODING_API_KEY");
+    if (!apiKey) {
+      console.error("GOOGLE_MAPS_GEOCODING_API_KEY is not set");
+      return new Response(
+        JSON.stringify({ error: "Geocoding is not configured" }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const url = new URL("https://maps.googleapis.com/maps/api/geocode/json");
+    url.searchParams.set("address", address);
+    url.searchParams.set("key", apiKey);
+
+    const gRes = await fetch(url.toString());
+    const gJson = (await gRes.json()) as {
+      status: string;
+      results?: Array<{
+        formatted_address?: string;
+        partial_match?: boolean;
+        address_components?: AddressComponent[];
+        geometry?: {
+          location?: { lat: number; lng: number };
+          location_type?: string;
+        };
+      }>;
+      error_message?: string;
+    };
+
+    if (gJson.status === "ZERO_RESULTS" || !gJson.results?.length) {
+      return new Response(
+        JSON.stringify({
+          error:
+            "Address not found. Check street, city, state, and ZIP.",
+        }),
+        {
+          status: 404,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    if (gJson.status !== "OK") {
+      const msg =
+        gJson.error_message || `Geocoding request failed (${gJson.status})`;
+      console.error("Geocoding API error", gJson.status, gJson.error_message);
+      return new Response(JSON.stringify({ error: msg }), {
+        status: 502,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const first = gJson.results[0];
+    const loc = first.geometry?.location;
+    if (typeof loc?.lat !== "number" || typeof loc?.lng !== "number") {
+      return new Response(
+        JSON.stringify({ error: "Invalid geocoding response" }),
+        {
+          status: 502,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const locationType = first.geometry?.location_type ?? "";
+    if (locationType === "GEOMETRIC_CENTER") {
+      return new Response(
+        JSON.stringify({
+          error:
+            "That search only matched a general area. Enter a full street address with number.",
+        }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    if (doComponentCheck) {
+      const { postalDigits: gotZip, state: gotState } = extractPostalAndState(
+        first.address_components,
+      );
+      const wantZip = zipToFiveDigits(expectZip);
+      const wantState = normalizeStateTwoLetter(expectRegion);
+
+      if (wantZip && !gotZip) {
+        return new Response(
+          JSON.stringify({
+            error:
+              "Could not verify ZIP for this address. Check the street and city.",
+          }),
+          {
+            status: 400,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      if (wantState && !gotState) {
+        return new Response(
+          JSON.stringify({
+            error:
+              "Could not verify state for this address. Check spelling.",
+          }),
+          {
+            status: 400,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      if (gotZip && wantZip && gotZip !== wantZip) {
+        return new Response(
+          JSON.stringify({
+            error:
+              `ZIP code does not match the location found (${gotZip}). Check city and ZIP.`,
+          }),
+          {
+            status: 400,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      if (gotState && wantState && gotState.toUpperCase() !== wantState) {
+        return new Response(
+          JSON.stringify({
+            error:
+              `State does not match the location found (${gotState}). Check your address.`,
+          }),
+          {
+            status: 400,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          },
+        );
+      }
+    }
+
+    const warnings: string[] = [];
+    if (first.partial_match) {
+      warnings.push(
+        "We could not fully match every part of your address—double-check the street number and spelling.",
+      );
+    }
+    if (locationType === "APPROXIMATE") {
+      warnings.push(
+        "The map location is approximate—confirm this is the correct storefront.",
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        latitude: loc.lat,
+        longitude: loc.lng,
+        formatted_address: first.formatted_address,
+        ...(warnings.length ? { warnings } : {}),
+      }),
+      {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
+  } catch (e) {
+    console.error(e);
+    return new Response(JSON.stringify({ error: "Internal error" }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});

--- a/Buyinz/supabase/migrations/20260415120000_remove_specific_sale_listings.sql
+++ b/Buyinz/supabase/migrations/20260415120000_remove_specific_sale_listings.sql
@@ -1,0 +1,24 @@
+-- One-time removal of specific sale listings (and related chat) by title.
+-- Order matches public.delete_own_sale_listing: messages, conversations, posts.
+-- user_ratings rows tied to those conversations are removed via ON DELETE CASCADE on conversations.
+
+delete from public.messages
+where conversation_id in (
+  select c.id
+  from public.conversations c
+  inner join public.posts p on p.id = c.listing_id
+  where p.type = 'sale'
+    and p.title in ('A good boy', 'Beautiful Zachary Chud')
+);
+
+delete from public.conversations
+where listing_id in (
+  select id
+  from public.posts
+  where type = 'sale'
+    and title in ('A good boy', 'Beautiful Zachary Chud')
+);
+
+delete from public.posts
+where type = 'sale'
+  and title in ('A good boy', 'Beautiful Zachary Chud');

--- a/Buyinz/supabase/migrations/20260418120000_users_account_type_store_address.sql
+++ b/Buyinz/supabase/migrations/20260418120000_users_account_type_store_address.sql
@@ -1,0 +1,42 @@
+-- Store vs user account classification and store physical address + geocoded coordinates.
+
+alter table public.users
+  add column if not exists account_type text not null default 'user';
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'users_account_type_check'
+  ) then
+    alter table public.users
+      add constraint users_account_type_check
+      check (account_type in ('user', 'store'));
+  end if;
+end $$;
+
+comment on column public.users.account_type is 'Discriminator: shopper (user) vs thrift store account.';
+
+alter table public.users
+  add column if not exists address_line1 text,
+  add column if not exists city text,
+  add column if not exists region text,
+  add column if not exists postal_code text,
+  add column if not exists address_string text,
+  add column if not exists latitude double precision,
+  add column if not exists longitude double precision,
+  add column if not exists formatted_address text;
+
+comment on column public.users.address_line1 is 'Store: street line.';
+comment on column public.users.city is 'Store: city.';
+comment on column public.users.region is 'Store: state/region.';
+comment on column public.users.postal_code is 'Store: ZIP/postal code.';
+comment on column public.users.address_string is 'Full address string used for geocoding and display.';
+comment on column public.users.latitude is 'Geocoded latitude (store accounts; distance discovery).';
+comment on column public.users.longitude is 'Geocoded longitude (store accounts; distance discovery).';
+comment on column public.users.formatted_address is 'Formatted address from geocoder (e.g. Google).';
+
+create index if not exists users_latitude_longitude_idx
+  on public.users (latitude, longitude)
+  where latitude is not null and longitude is not null;

--- a/Buyinz/supabase/postsInsert.ts
+++ b/Buyinz/supabase/postsInsert.ts
@@ -59,6 +59,7 @@ export async function insertPost(draft: ListingDraft, userId?: string): Promise<
       user_id: userId || DEFAULT_MOCK_USER_ID,
       type: 'sale',
       title: draft.title,
+      category: draft.category,
       price: parsePriceToNumber(draft.price),
       images: imageUrls,
     })

--- a/Buyinz/tests/addressValidation.test.ts
+++ b/Buyinz/tests/addressValidation.test.ts
@@ -1,0 +1,75 @@
+import {
+  isValidUsStateCode,
+  isValidUsZipFormat,
+  normalizeUsStateRegion,
+  normalizeUsZipToFiveDigits,
+  validateUsStoreAddressFormat,
+} from '../lib/addressValidation';
+
+describe('normalizeUsZipToFiveDigits', () => {
+  it('returns first five digits', () => {
+    expect(normalizeUsZipToFiveDigits('15213-1234')).toBe('15213');
+    expect(normalizeUsZipToFiveDigits('15213')).toBe('15213');
+  });
+});
+
+describe('isValidUsZipFormat', () => {
+  it('accepts 5-digit and ZIP+4', () => {
+    expect(isValidUsZipFormat('15213')).toBe(true);
+    expect(isValidUsZipFormat('15213-1234')).toBe(true);
+  });
+
+  it('rejects invalid', () => {
+    expect(isValidUsZipFormat('1234')).toBe(false);
+    expect(isValidUsZipFormat('')).toBe(false);
+    expect(isValidUsZipFormat('1521-1234')).toBe(false);
+  });
+});
+
+describe('normalizeUsStateRegion and isValidUsStateCode', () => {
+  it('normalizes to two uppercase letters', () => {
+    expect(normalizeUsStateRegion('pa')).toBe('PA');
+    expect(normalizeUsStateRegion('Pa ')).toBe('PA');
+  });
+
+  it('validates two-letter codes', () => {
+    expect(isValidUsStateCode('PA')).toBe(true);
+    expect(isValidUsStateCode('pa')).toBe(true);
+    expect(isValidUsStateCode('P')).toBe(false);
+    expect(isValidUsStateCode('Penn')).toBe(false);
+  });
+});
+
+describe('validateUsStoreAddressFormat', () => {
+  it('passes a typical US store address', () => {
+    expect(
+      validateUsStoreAddressFormat({
+        address_line1: '5000 Forbes Ave',
+        city: 'Pittsburgh',
+        region: 'PA',
+        postal_code: '15213',
+      }).ok,
+    ).toBe(true);
+  });
+
+  it('fails bad ZIP', () => {
+    const r = validateUsStoreAddressFormat({
+      address_line1: '1 Main St',
+      city: 'Town',
+      region: 'PA',
+      postal_code: '1234',
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.message).toMatch(/ZIP/i);
+  });
+
+  it('fails non-two-letter state', () => {
+    const r = validateUsStoreAddressFormat({
+      address_line1: '1 Main St',
+      city: 'Town',
+      region: 'Pennsylvania',
+      postal_code: '15213',
+    });
+    expect(r.ok).toBe(false);
+  });
+});

--- a/Buyinz/tests/listings.test.ts
+++ b/Buyinz/tests/listings.test.ts
@@ -19,6 +19,7 @@ function minimalValidDraft(overrides: Partial<ListingDraft> = {}): ListingDraft 
     images: [{ uri: 'file:///photo.jpg', width: 800, height: 600 }],
     title: 'Desk lamp',
     price: '19.99',
+    category: 'Other',
     ...overrides,
   };
 }
@@ -29,6 +30,7 @@ describe('constants', () => {
       images: [],
       title: '',
       price: '',
+      category: 'Other',
     });
   });
 

--- a/Buyinz/tests/postsInsert-tests.ts
+++ b/Buyinz/tests/postsInsert-tests.ts
@@ -233,6 +233,7 @@ describe('postsInsert', () => {
         images: [{ uri: 'https://cdn/item.JPG', width: 1, height: 1 }],
         title: 'Desk',
         price: '45',
+        category: 'Furniture',
         ...overrides,
       };
     }
@@ -278,6 +279,7 @@ describe('postsInsert', () => {
         user_id: '11111111-1111-1111-1111-111111111111',
         type: 'sale',
         title: 'Desk',
+        category: 'Furniture',
         price: 45,
         images: ['https://example.test/object/1700000000000-zzzj7c.jpg'],
       });

--- a/Buyinz/tests/supabase.test.ts
+++ b/Buyinz/tests/supabase.test.ts
@@ -10,6 +10,9 @@ jest.mock('@/supabase/client', () => ({
       signUp: jest.fn(),
       signInWithOAuth: jest.fn(),
     },
+    functions: {
+      invoke: jest.fn(),
+    },
   },
 }));
 
@@ -26,6 +29,7 @@ import {
   isProfileOnboardingComplete,
   profileCoreComplete,
   saveProfile,
+  storeAddressPartsComplete,
   validateProfileForSave,
 } from '../lib/supabase';
 
@@ -68,6 +72,7 @@ describe('validateProfileForSave', () => {
   it('throws when username is missing', () => {
     expect(() =>
       validateProfileForSave({
+        account_type: 'user',
         display_name: 'Test User',
         username: '',
         location: '90210',
@@ -78,6 +83,7 @@ describe('validateProfileForSave', () => {
   it('allows missing bio', () => {
     expect(() =>
       validateProfileForSave({
+        account_type: 'user',
         display_name: 'Test User',
         username: 'u1',
         location: '90210',
@@ -100,6 +106,7 @@ describe('profileCoreComplete and onboarding', () => {
   it('isProfileOnboardingComplete is true without bio', () => {
     expect(
       isProfileOnboardingComplete({
+        account_type: 'user',
         display_name: 'A',
         username: 'b',
         location: '90210',
@@ -111,12 +118,71 @@ describe('profileCoreComplete and onboarding', () => {
   it('isBuyinzProfileComplete matches isProfileOnboardingComplete', () => {
     expect(
       isBuyinzProfileComplete({
+        account_type: 'user',
         display_name: 'Jane',
         username: 'jane',
         location: '10001',
         bio: null,
       }),
     ).toBe(true);
+  });
+
+  it('isProfileOnboardingComplete is true for store when address and coords set', () => {
+    expect(
+      isProfileOnboardingComplete({
+        account_type: 'store',
+        display_name: 'Thrift Co',
+        username: 'thriftco',
+        location: '15213',
+        address_line1: '123 Main St',
+        city: 'Pittsburgh',
+        region: 'PA',
+        postal_code: '15213',
+        latitude: 40.44,
+        longitude: -79.99,
+      }),
+    ).toBe(true);
+  });
+
+  it('isProfileOnboardingComplete is false for store without coordinates', () => {
+    expect(
+      isProfileOnboardingComplete({
+        account_type: 'store',
+        display_name: 'Thrift Co',
+        username: 'thriftco',
+        location: '15213',
+        address_line1: '123 Main St',
+        city: 'Pittsburgh',
+        region: 'PA',
+        postal_code: '15213',
+        latitude: null,
+        longitude: null,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('storeAddressPartsComplete', () => {
+  it('is true when all parts non-empty', () => {
+    expect(
+      storeAddressPartsComplete({
+        address_line1: '1 A St',
+        city: 'Pittsburgh',
+        region: 'PA',
+        postal_code: '15213',
+      }),
+    ).toBe(true);
+  });
+
+  it('is false when a part is empty', () => {
+    expect(
+      storeAddressPartsComplete({
+        address_line1: '1 A St',
+        city: '',
+        region: 'PA',
+        postal_code: '15213',
+      }),
+    ).toBe(false);
   });
 });
 
@@ -152,6 +218,7 @@ describe('buildUsersUpsertPayload', () => {
   it('maps UserProfile fields to the users table upsert columns', () => {
     const profile = {
       id: '550e8400-e29b-41d4-a716-446655440000',
+      account_type: 'user' as const,
       display_name: 'Jane Buyer',
       username: 'jane_buyer',
       location: '10001',
@@ -162,11 +229,20 @@ describe('buildUsersUpsertPayload', () => {
 
     expect(buildUsersUpsertPayload(profile)).toEqual({
       id: '550e8400-e29b-41d4-a716-446655440000',
+      account_type: 'user',
       display_name: 'Jane Buyer',
       username: 'jane_buyer',
       location: '10001',
       bio: 'Looking for deals',
       avatar_url: 'https://cdn.example/avatar.jpg',
+      address_line1: null,
+      city: null,
+      region: null,
+      postal_code: null,
+      address_string: null,
+      latitude: null,
+      longitude: null,
+      formatted_address: null,
     });
   });
 });
@@ -209,6 +285,7 @@ describe('saveProfile', () => {
 
     await expect(
       saveProfile({
+        account_type: 'user',
         display_name: 'Test',
         username: 'taken_name',
         location: '90210',

--- a/Buyinz/tsconfig.json
+++ b/Buyinz/tsconfig.json
@@ -13,5 +13,8 @@
     "**/*.tsx",
     ".expo/types/**/*.ts",
     "expo-env.d.ts"
+  ],
+  "exclude": [
+    "supabase/functions"
   ]
 }


### PR DESCRIPTION
#88 

## Store profiles, geocoding, listings, and edit rules

### Summary
Adds **store vs shopper** onboarding with **geocoded store addresses**, **stricter US address checks**, **category on new listings** (fixes DB NOT NULL on `posts.category`), and **limited store edit profile** (business name, username, bio only; address read-only).

### Changes
- **Database:** `account_type`, store address columns, lat/lng, `formatted_address` on `users` ([migration](Buyinz/supabase/migrations/20260418120000_users_account_type_store_address.sql)).
- **Edge function:** `geocode-address` (Google Geocoding, JWT auth in-function; `verify_jwt = false` in [config](Buyinz/supabase/config.toml) for ES256 tokens); ZIP/state checks and warnings on the response.
- **App:** `lib/addressValidation.ts`, `lib/supabase.ts` updates; **create-profile** flow (shopper vs store, geocode on store save); **edit-profile** — stores can’t change address or photo; **listings** — `category` on draft + insert + UI chips.
- **Tests:** Address helpers + updated listing/post insert tests.

### Deploy / ops
- Apply migration; redeploy **`geocode-address`**; set **`GOOGLE_MAPS_GEOCODING_API_KEY`** secret.

### How to test
- Onboard as store → address geocodes → profile saves.
- Create listing → pick category → insert succeeds.
- Edit store profile → only name, handle, bio; address shown read-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added listing categories (Furniture, Clothing, Electronics, Books, Decor, Other) with visual indicators when creating new items.
  * Users can now choose to create a Shopper or Thrift Store account during signup, each with customized onboarding.
  * Store accounts collect full address information with automatic location validation and geocoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->