### PR TITLE
Created machine acceptance tests for store profile creation and locat…

### DIFF
--- a/Buyinz/tests/storeProfileLocation.test.ts
+++ b/Buyinz/tests/storeProfileLocation.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Store account creation & location setup — data-layer behavior aligned with the user story:
+ * structured address, geocoded lat/lng, US format checks, and DB payload shape.
+ *
+ * Avoids real network: mocks Supabase client (no actual API calls).
+ */
+
+jest.mock('expo-linking', () => ({
+  createURL: jest.fn(() => 'exp://test/auth/callback'),
+}));
+
+jest.mock('@/supabase/client', () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn(),
+    },
+    functions: {
+      invoke: jest.fn(),
+    },
+  },
+}));
+
+import { supabase } from '@/supabase/client';
+import {
+  validateUsStoreAddressFormat,
+  normalizeUsStateRegion,
+} from '../lib/addressValidation';
+import {
+  buildUsersUpsertPayload,
+  composeStoreAddressString,
+  geocodeAddressString,
+  isProfileOnboardingComplete,
+  validateOnboardingSave,
+} from '../lib/supabase';
+
+const getSessionMock = supabase.auth.getSession as jest.Mock;
+const functionsInvokeMock = supabase.functions.invoke as jest.Mock;
+
+describe('Store profile & location (user story)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('isProfileOnboardingComplete', () => {
+    it('is false for store when address parts exist but coordinates are missing', () => {
+      expect(
+        isProfileOnboardingComplete({
+          account_type: 'store',
+          display_name: 'Thrift Co',
+          username: 'thriftco',
+          location: '15213',
+          address_line1: '5000 Forbes Ave',
+          city: 'Pittsburgh',
+          region: 'PA',
+          postal_code: '15213',
+          latitude: null,
+          longitude: null,
+        }),
+      ).toBe(false);
+    });
+
+    it('is true for store when business name, handle, address, and geocoded coords are present', () => {
+      expect(
+        isProfileOnboardingComplete({
+          account_type: 'store',
+          display_name: 'Thrift Co',
+          username: 'thriftco',
+          location: '15213',
+          address_line1: '5000 Forbes Ave',
+          city: 'Pittsburgh',
+          region: 'PA',
+          postal_code: '15213',
+          latitude: 40.4433,
+          longitude: -79.9436,
+        }),
+      ).toBe(true);
+    });
+
+    it('does not require store-style address fields for shopper accounts', () => {
+      expect(
+        isProfileOnboardingComplete({
+          account_type: 'user',
+          display_name: 'Alex',
+          username: 'alex',
+          location: '15213',
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe('composeStoreAddressString', () => {
+    it('joins trimmed parts into a single line for geocoding', () => {
+      expect(
+        composeStoreAddressString({
+          address_line1: '  123 Main St  ',
+          city: 'Pittsburgh',
+          region: 'PA',
+          postal_code: '15213',
+        }),
+      ).toBe('123 Main St, Pittsburgh, PA, 15213');
+    });
+  });
+
+  describe('validateUsStoreAddressFormat', () => {
+    it('rejects invalid ZIP (user story: collect valid address parts before geocode)', () => {
+      const r = validateUsStoreAddressFormat({
+        address_line1: '1 Main',
+        city: 'Pittsburgh',
+        region: 'PA',
+        postal_code: '123',
+      });
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.message).toMatch(/ZIP/i);
+      }
+    });
+
+    it('accepts valid US ZIP and 2-letter state', () => {
+      expect(
+        validateUsStoreAddressFormat({
+          address_line1: '5000 Forbes Ave',
+          city: 'Pittsburgh',
+          region: 'pa',
+          postal_code: '15213-1234',
+        }).ok,
+      ).toBe(true);
+    });
+  });
+
+  describe('normalizeUsStateRegion', () => {
+    it('normalizes state to 2 uppercase letters for geocode options', () => {
+      expect(normalizeUsStateRegion(' pa ')).toBe('PA');
+    });
+  });
+
+  describe('validateOnboardingSave', () => {
+    it('throws for store profile missing coordinates (location not verified)', () => {
+      expect(() =>
+        validateOnboardingSave({
+          account_type: 'store',
+          display_name: 'Shop',
+          username: 'shop1',
+          location: '15213',
+          address_line1: '1 St',
+          city: 'City',
+          region: 'PA',
+          postal_code: '15213',
+          latitude: null,
+          longitude: null,
+        }),
+      ).toThrow(
+        'Missing mandatory fields: business name, handle, full address, or location could not be verified.',
+      );
+    });
+
+    it('allows store save when coordinates and address are complete', () => {
+      expect(() =>
+        validateOnboardingSave({
+          account_type: 'store',
+          display_name: 'Shop',
+          username: 'shop1',
+          location: '15213',
+          address_line1: '1 Main St',
+          city: 'Pittsburgh',
+          region: 'PA',
+          postal_code: '15213',
+          address_string: '1 Main St, Pittsburgh, PA, 15213',
+          latitude: 40.44,
+          longitude: -79.99,
+          formatted_address: '1 Main St, Pittsburgh, PA 15213, USA',
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  describe('buildUsersUpsertPayload', () => {
+    it('includes account_type, address fields, and coordinates for store rows', () => {
+      const payload = buildUsersUpsertPayload({
+        id: 'user-uuid',
+        account_type: 'store',
+        display_name: 'My Store',
+        username: 'mystore',
+        location: '15213',
+        bio: undefined,
+        address_line1: '1 St',
+        city: 'Pittsburgh',
+        region: 'PA',
+        postal_code: '15213',
+        address_string: '1 St, Pittsburgh, PA, 15213',
+        latitude: 40.4,
+        longitude: -79.9,
+        formatted_address: 'formatted',
+      });
+
+      expect(payload).toEqual(
+        expect.objectContaining({
+          account_type: 'store',
+          address_line1: '1 St',
+          city: 'Pittsburgh',
+          region: 'PA',
+          postal_code: '15213',
+          latitude: 40.4,
+          longitude: -79.9,
+          formatted_address: 'formatted',
+        }),
+      );
+      expect(payload.location).toBe('15213');
+    });
+  });
+
+  describe('geocodeAddressString', () => {
+    it('throws when address is empty or whitespace', async () => {
+      getSessionMock.mockResolvedValue({
+        data: { session: { access_token: 'tok' } },
+      });
+      await expect(geocodeAddressString('   ')).rejects.toThrow(
+        'Address is required for geocoding.',
+      );
+    });
+
+    it('throws when there is no authenticated session', async () => {
+      getSessionMock.mockResolvedValue({ data: { session: null } });
+      await expect(
+        geocodeAddressString('5000 Forbes Ave, Pittsburgh, PA, 15213'),
+      ).rejects.toThrow('Sign in again to verify your address.');
+    });
+
+    it('calls geocode-address with address and expected ZIP/state when options provided', async () => {
+      getSessionMock.mockResolvedValue({
+        data: { session: { access_token: 'jwt-token' } },
+      });
+      functionsInvokeMock.mockResolvedValue({
+        data: {
+          latitude: 40.44,
+          longitude: -79.99,
+          formatted_address: '5000 Forbes Ave, Pittsburgh, PA 15213, USA',
+        },
+        error: null,
+        response: undefined,
+      });
+
+      const result = await geocodeAddressString(
+        '5000 Forbes Ave, Pittsburgh, PA, 15213',
+        { expectedPostalCode: '15213', expectedRegion: 'PA' },
+      );
+
+      expect(result.latitude).toBe(40.44);
+      expect(result.longitude).toBe(-79.99);
+      expect(result.formatted_address).toContain('Pittsburgh');
+
+      expect(functionsInvokeMock).toHaveBeenCalledWith(
+        'geocode-address',
+        expect.objectContaining({
+          body: expect.objectContaining({
+            address: '5000 Forbes Ave, Pittsburgh, PA, 15213',
+            expected_postal_code: '15213',
+            expected_region: 'PA',
+          }),
+          headers: { Authorization: 'Bearer jwt-token' },
+        }),
+      );
+    });
+
+    it('returns warnings from Edge Function when present', async () => {
+      getSessionMock.mockResolvedValue({
+        data: { session: { access_token: 'tok' } },
+      });
+      functionsInvokeMock.mockResolvedValue({
+        data: {
+          latitude: 40.0,
+          longitude: -80.0,
+          warnings: ['Approximate location.'],
+        },
+        error: null,
+      });
+
+      const result = await geocodeAddressString('Some St, City, PA, 15213');
+      expect(result.warnings).toEqual(['Approximate location.']);
+    });
+
+    it('throws with message when invoke returns error', async () => {
+      getSessionMock.mockResolvedValue({
+        data: { session: { access_token: 'tok' } },
+      });
+      const zipMismatch = 'ZIP code does not match the location found (15120).';
+      const fnResponse = {
+        json: jest.fn(),
+        clone() {
+          return {
+            json: async () => ({ error: zipMismatch }),
+          };
+        },
+      };
+      functionsInvokeMock.mockResolvedValue({
+        data: null,
+        error: new Error('Edge Function returned a non-2xx status code'),
+        response: fnResponse,
+      });
+
+      await expect(
+        geocodeAddressString('x', { expectedPostalCode: '15213', expectedRegion: 'PA' }),
+      ).rejects.toThrow(zipMismatch);
+    });
+  });
+});


### PR DESCRIPTION
…ion setup user story

#95 


## PR description: `tests/storeProfileLocation.test.ts`

### Summary

Adds **`Buyinz/tests/storeProfileLocation.test.ts`**, a Jest suite that pins the **data-layer behavior** for the **store account creation and location setup** story: structured US address fields, client-side format checks, composing the geocode input string, requiring **verified coordinates** before a store profile counts as complete or savable, shaping the **`users` upsert payload**, and calling the **`geocode-address`** Edge Function with the right body and auth—**without** hitting Supabase or the network (Supabase `auth.getSession` and `functions.invoke` are mocked).

---

### Machine-checkable acceptance criteria ↔ tests

Below, “acceptance criteria” are phrased as verifiable behaviors the app and backend must satisfy; each bullet maps to the **`it(...)`** test that asserts it.

| Acceptance criterion (machine-checkable) | Test | What it asserts |
|------------------------------------------|------|-----------------|
| A **store** cannot finish onboarding until the profile has **geocoded latitude and longitude**, not only typed address fields. | `isProfileOnboardingComplete` → *is false for store when address parts exist but coordinates are missing* | `isProfileOnboardingComplete` returns `false` when `account_type: 'store'`, address parts are filled, and `latitude` / `longitude` are `null`. |
| A **store** can finish onboarding when business identity, full address, and **numeric lat/lng** are present. | `isProfileOnboardingComplete` → *is true for store when business name, handle, address, and geocoded coords are present* | Returns `true` for a store row with name, username, address fields, and numeric coords. |
| **Shopper (`user`)** onboarding is **not** gated on store-only address/coordinate fields. | `isProfileOnboardingComplete` → *does not require store-style address fields for shopper accounts* | Returns `true` for `account_type: 'user'` with only name, username, and zip-style `location`. |
| The app builds **one address string** from structured fields for the geocoder. | `composeStoreAddressString` → *joins trimmed parts into a single line for geocoding* | Output is trimmed segments joined as `"street, city, region, postal"`. |
| **Invalid US ZIP** is rejected **before** geocoding; **valid ZIP + 2-letter state** passes format checks. | `validateUsStoreAddressFormat` → *rejects invalid ZIP…* and *accepts valid US ZIP and 2-letter state* | Invalid short ZIP yields `ok: false` and a ZIP-related message; valid ZIP (including +4) and state pass. |
| State input is normalized for options sent with geocode (e.g. **2-letter uppercase**). | `normalizeUsStateRegion` → *normalizes state to 2 uppercase letters for geocode options* | e.g. `' pa '` → `'PA'`. |
| Saving onboarding for a **store** is blocked if location was **not verified** (no coordinates). | `validateOnboardingSave` → *throws for store profile missing coordinates (location not verified)* | Throws the exact error: missing mandatory fields / location could not be verified. |
| Saving onboarding for a **store** is allowed when address and **verified** coords (and related fields) are present. | `validateOnboardingSave` → *allows store save when coordinates and address are complete* | Does not throw when store profile includes coords and formatted address fields. |
| Persisting a store profile sends **`account_type`**, structured address fields, **`location`** (mirroring postal), and **lat/lng / formatted** fields to `users`. | `buildUsersUpsertPayload` → *includes account_type, address fields, and coordinates for store rows* | Payload `objectContaining` store address and coords; `location` equals postal string used in the test. |
| Geocoding requires a **non-empty** address string. | `geocodeAddressString` → *throws when address is empty or whitespace* | Throws `Address is required for geocoding.` |
| Geocoding requires an **authenticated session** (access token). | `geocodeAddressString` → *throws when there is no authenticated session* | Throws `Sign in again to verify your address.` when `getSession` returns no session. |
| The client invokes **`geocode-address`** with **address**, optional **`expected_postal_code` / `expected_region`**, and **`Authorization: Bearer &lt;token&gt;`**. | `geocodeAddressString` → *calls geocode-address with address and expected ZIP/state when options provided* | Mock `invoke` called with matching `body` and `headers`; result lat/lng and formatted address returned. |
| **Warnings** from the Edge Function (e.g. partial match) are surfaced on the result. | `geocodeAddressString` → *returns warnings from Edge Function when present* | `warnings` array passed through on success. |
| When **`functions.invoke` errors**, the client surfaces a **useful message** (e.g. ZIP mismatch from response body). | `geocodeAddressString` → *throws with message when invoke returns error* | Rejects with the JSON `error` string when the mock response supports `clone().json()`. |

---

### Scope note

These tests cover **lib-level** rules and the **geocode client contract**. They do not drive the full Expo UI or a live Supabase instance; those remain for manual or E2E verification. Together they give repeatable checks that the implementation still matches the story’s **completion rules**, **validation order** (format → geocode → save), **payload shape**, and **Edge Function** integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for store profile onboarding, address validation, geocoding, and location handling across multiple data-layer functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->