### PR TITLE
Feature PR Title: Discover: distance-sorted store feed with CMU location fallback

### DIFF
--- a/Buyinz/app/(tabs)/explore.tsx
+++ b/Buyinz/app/(tabs)/explore.tsx
@@ -17,12 +17,8 @@ import { Ionicons } from '@expo/vector-icons';
 import { Brand, Colors, Fonts } from '@/constants/theme';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { useAuth } from '@/contexts/AuthContext';
-import {
-  DEFAULT_PITTSBURGH_COORDS,
-  fetchDiscoveryFeed,
-  type DiscoverySalePost,
-  type GeoPoint,
-} from '@/supabase/queries';
+import { fetchDiscoveryFeed, type DiscoverySalePost, type GeoPoint } from '@/supabase/queries';
+import { DEFAULT_CMU_COORDS, milesBetween } from '@/lib/discoveryLocation';
 
 const SHELVES = [
   { id: 'All', label: 'All Shelves', emoji: '🏪' },
@@ -42,19 +38,7 @@ const RADIUS_OPTIONS: { label: string; miles: number }[] = [
   { label: '20 mi', miles: 20 },
 ];
 
-function milesBetween(a: GeoPoint, b: GeoPoint): number {
-  const earthRadiusMiles = 3958.8;
-  const dLat = ((b.latitude - a.latitude) * Math.PI) / 180;
-  const dLon = ((b.longitude - a.longitude) * Math.PI) / 180;
-  const lat1 = (a.latitude * Math.PI) / 180;
-  const lat2 = (b.latitude * Math.PI) / 180;
-
-  const h =
-    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-    Math.sin(dLon / 2) * Math.sin(dLon / 2) * Math.cos(lat1) * Math.cos(lat2);
-
-  return 2 * earthRadiusMiles * Math.asin(Math.sqrt(h));
-}
+const DEFAULT_RADIUS_MILES = 10;
 
 function ExploreCard({ post }: { post: DiscoverySalePost }) {
   const router = useRouter();
@@ -100,14 +84,13 @@ export default function ExploreTabScreen() {
 
   const [search, setSearch] = useState('');
   const [activeCategory, setActiveCategory] = useState<ShelfId>('All');
-  const [activeRadius, setActiveRadius] = useState(0);
+  const [activeRadius, setActiveRadius] = useState(DEFAULT_RADIUS_MILES);
 
-  const [userCoords, setUserCoords] = useState<GeoPoint>(DEFAULT_PITTSBURGH_COORDS);
-  const [neighborhood, setNeighborhood] = useState('Pittsburgh');
+  const [userCoords, setUserCoords] = useState<GeoPoint>(DEFAULT_CMU_COORDS);
   const [listings, setListings] = useState<DiscoverySalePost[]>([]);
   const [loading, setLoading] = useState(true);
 
-  const lastCoordsRef = useRef<GeoPoint>(DEFAULT_PITTSBURGH_COORDS);
+  const lastCoordsRef = useRef<GeoPoint>(DEFAULT_CMU_COORDS);
 
   useEffect(() => {
     if (!user) return;
@@ -152,9 +135,15 @@ export default function ExploreTabScreen() {
               }
             },
           );
+        } else if (mounted) {
+          lastCoordsRef.current = DEFAULT_CMU_COORDS;
+          setUserCoords(DEFAULT_CMU_COORDS);
         }
       } catch {
-        // Fall back to default Pittsburgh center.
+        if (mounted) {
+          lastCoordsRef.current = DEFAULT_CMU_COORDS;
+          setUserCoords(DEFAULT_CMU_COORDS);
+        }
       }
     })();
 
@@ -172,7 +161,6 @@ export default function ExploreTabScreen() {
     fetchDiscoveryFeed({ userCoords, radiusMiles: activeRadius })
       .then((result) => {
         if (!mounted) return;
-        setNeighborhood(result.neighborhood);
         setListings(result.listings);
       })
       .catch(console.error)
@@ -229,7 +217,9 @@ export default function ExploreTabScreen() {
         ]}
       >
         <Text style={[styles.title, { color: colors.text, fontFamily: Fonts.rounded }]}>Discover</Text>
-        <Text style={[styles.subtitle, { color: colors.textSecondary }]}>Trending in {neighborhood}</Text>
+        <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+          Store listings sorted by distance
+        </Text>
 
         <View style={[styles.searchWrap, { backgroundColor: colors.card, borderColor: colors.border }]}> 
           <Ionicons name="search" size={16} color={colors.textSecondary} />
@@ -461,17 +451,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
     gap: 8,
-  },
-  neighborhoodPill: {
-    backgroundColor: 'rgba(255,255,255,0.24)',
-    borderRadius: 999,
-    paddingHorizontal: 8,
-    paddingVertical: 3,
-  },
-  neighborhoodText: {
-    color: '#FFFFFF',
-    fontSize: 11,
-    fontWeight: '700',
   },
   distanceText: {
     color: '#FFFFFF',

--- a/Buyinz/data/mockData.ts
+++ b/Buyinz/data/mockData.ts
@@ -8,6 +8,9 @@ export interface Seller {
   followers: number;
   following: number;
   posts: number;
+  accountType: 'user' | 'store';
+  latitude: number | null;
+  longitude: number | null;
 }
 
 export interface SalePost {
@@ -56,6 +59,9 @@ export const MOCK_SELLERS: Seller[] = [
     followers: 1240,
     following: 380,
     posts: 9,
+    accountType: "store",
+    latitude: 40.4741,
+    longitude: -79.9563,
   },
   {
     id: "u2",
@@ -67,6 +73,9 @@ export const MOCK_SELLERS: Seller[] = [
     followers: 214,
     following: 102,
     posts: 14,
+    accountType: "user",
+    latitude: null,
+    longitude: null,
   },
   {
     id: "u3",
@@ -78,6 +87,9 @@ export const MOCK_SELLERS: Seller[] = [
     followers: 3100,
     following: 220,
     posts: 41,
+    accountType: "user",
+    latitude: null,
+    longitude: null,
   },
   {
     id: "u4",
@@ -89,6 +101,9 @@ export const MOCK_SELLERS: Seller[] = [
     followers: 890,
     following: 450,
     posts: 22,
+    accountType: "store",
+    latitude: 40.4508,
+    longitude: -79.9913,
   },
   {
     id: "u5",
@@ -100,6 +115,9 @@ export const MOCK_SELLERS: Seller[] = [
     followers: 560,
     following: 310,
     posts: 18,
+    accountType: "user",
+    latitude: null,
+    longitude: null,
   },
 ];
 

--- a/Buyinz/lib/discoveryLocation.ts
+++ b/Buyinz/lib/discoveryLocation.ts
@@ -3,110 +3,11 @@ export interface GeoPoint {
   longitude: number;
 }
 
-interface NeighborhoodPolygon {
-  name: string;
-  points: GeoPoint[];
-  center: GeoPoint;
-}
-
-export const DEFAULT_PITTSBURGH_COORDS: GeoPoint = {
-  latitude: 40.4406,
-  longitude: -79.9959,
+/** Default map center when location permission is denied (CMU main campus, ~Forbes & Morewood). */
+export const DEFAULT_CMU_COORDS: GeoPoint = {
+  latitude: 40.44306,
+  longitude: -79.9443,
 };
-
-const PITTSBURGH_NEIGHBORHOODS: NeighborhoodPolygon[] = [
-  {
-    name: 'Oakland',
-    points: [
-      { latitude: 40.4526, longitude: -79.9748 },
-      { latitude: 40.4488, longitude: -79.9567 },
-      { latitude: 40.4341, longitude: -79.9601 },
-      { latitude: 40.435, longitude: -79.9806 },
-    ],
-    center: { latitude: 40.4407, longitude: -79.9594 },
-  },
-  {
-    name: 'Shadyside',
-    points: [
-      { latitude: 40.4622, longitude: -79.9457 },
-      { latitude: 40.4572, longitude: -79.9248 },
-      { latitude: 40.4462, longitude: -79.9284 },
-      { latitude: 40.4482, longitude: -79.9468 },
-    ],
-    center: { latitude: 40.4518, longitude: -79.9358 },
-  },
-  {
-    name: 'Squirrel Hill',
-    points: [
-      { latitude: 40.4468, longitude: -79.9365 },
-      { latitude: 40.4398, longitude: -79.9106 },
-      { latitude: 40.4248, longitude: -79.9153 },
-      { latitude: 40.4289, longitude: -79.9402 },
-    ],
-    center: { latitude: 40.4342, longitude: -79.9222 },
-  },
-  {
-    name: 'Lawrenceville',
-    points: [
-      { latitude: 40.4852, longitude: -79.9723 },
-      { latitude: 40.4802, longitude: -79.9395 },
-      { latitude: 40.466, longitude: -79.9445 },
-      { latitude: 40.4687, longitude: -79.9766 },
-    ],
-    center: { latitude: 40.4741, longitude: -79.9563 },
-  },
-  {
-    name: 'Strip District',
-    points: [
-      { latitude: 40.4572, longitude: -80.0121 },
-      { latitude: 40.4555, longitude: -79.9767 },
-      { latitude: 40.4451, longitude: -79.9798 },
-      { latitude: 40.4467, longitude: -80.0116 },
-    ],
-    center: { latitude: 40.4508, longitude: -79.9913 },
-  },
-  {
-    name: 'North Side',
-    points: [
-      { latitude: 40.4648, longitude: -80.0264 },
-      { latitude: 40.4662, longitude: -79.9911 },
-      { latitude: 40.4462, longitude: -79.9939 },
-      { latitude: 40.4455, longitude: -80.0258 },
-    ],
-    center: { latitude: 40.4542, longitude: -80.0078 },
-  },
-  {
-    name: 'Mount Washington',
-    points: [
-      { latitude: 40.4442, longitude: -80.0222 },
-      { latitude: 40.4382, longitude: -79.9968 },
-      { latitude: 40.4216, longitude: -80.0018 },
-      { latitude: 40.4236, longitude: -80.0273 },
-    ],
-    center: { latitude: 40.4326, longitude: -80.0109 },
-  },
-  {
-    name: 'Point Breeze',
-    points: [
-      { latitude: 40.4586, longitude: -79.9203 },
-      { latitude: 40.4538, longitude: -79.8961 },
-      { latitude: 40.4418, longitude: -79.8998 },
-      { latitude: 40.4446, longitude: -79.9232 },
-    ],
-    center: { latitude: 40.4501, longitude: -79.9108 },
-  },
-];
-
-const LOCATION_TO_COORDINATE: { match: string; point: GeoPoint }[] = [
-  { match: 'oakland', point: { latitude: 40.4407, longitude: -79.9594 } },
-  { match: 'shadyside', point: { latitude: 40.4518, longitude: -79.9358 } },
-  { match: 'squirrel hill', point: { latitude: 40.4342, longitude: -79.9222 } },
-  { match: 'lawrenceville', point: { latitude: 40.4741, longitude: -79.9563 } },
-  { match: 'strip district', point: { latitude: 40.4508, longitude: -79.9913 } },
-  { match: 'north side', point: { latitude: 40.4542, longitude: -80.0078 } },
-  { match: 'mount washington', point: { latitude: 40.4326, longitude: -80.0109 } },
-  { match: 'point breeze', point: { latitude: 40.4501, longitude: -79.9108 } },
-];
 
 export function milesBetween(a: GeoPoint, b: GeoPoint): number {
   const earthRadiusMiles = 3958.8;
@@ -120,54 +21,4 @@ export function milesBetween(a: GeoPoint, b: GeoPoint): number {
     Math.sin(dLon / 2) * Math.sin(dLon / 2) * Math.cos(lat1) * Math.cos(lat2);
 
   return 2 * earthRadiusMiles * Math.asin(Math.sqrt(h));
-}
-
-export function isPointInPolygon(point: GeoPoint, polygon: GeoPoint[]): boolean {
-  let inside = false;
-  const x = point.longitude;
-  const y = point.latitude;
-
-  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
-    const xi = polygon[i].longitude;
-    const yi = polygon[i].latitude;
-    const xj = polygon[j].longitude;
-    const yj = polygon[j].latitude;
-
-    const intersects =
-      yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi + Number.EPSILON) + xi;
-    if (intersects) inside = !inside;
-  }
-
-  return inside;
-}
-
-export function resolveNeighborhood(point: GeoPoint): string {
-  const containing = PITTSBURGH_NEIGHBORHOODS.find((hood) =>
-    isPointInPolygon(point, hood.points),
-  );
-  if (containing) return containing.name;
-
-  let nearest = PITTSBURGH_NEIGHBORHOODS[0];
-  let nearestDistance = Number.POSITIVE_INFINITY;
-
-  for (const hood of PITTSBURGH_NEIGHBORHOODS) {
-    const d = milesBetween(point, hood.center);
-    if (d < nearestDistance) {
-      nearest = hood;
-      nearestDistance = d;
-    }
-  }
-
-  return nearest.name;
-}
-
-/** Lowercase trim for matching neighborhood substrings in `LOCATION_TO_COORDINATE`. */
-export function normalizeLocationQuery(location: string): string {
-  return location.trim().toLowerCase();
-}
-
-export function coordinateFromLocation(location: string): GeoPoint | null {
-  const normalized = normalizeLocationQuery(location);
-  const mapping = LOCATION_TO_COORDINATE.find((entry) => normalized.includes(entry.match));
-  return mapping?.point ?? null;
 }

--- a/Buyinz/supabase/discoveryFeed.ts
+++ b/Buyinz/supabase/discoveryFeed.ts
@@ -1,72 +1,58 @@
 import type { SalePost } from '@/data/mockData';
-import {
-  coordinateFromLocation,
-  DEFAULT_PITTSBURGH_COORDS,
-  milesBetween,
-  resolveNeighborhood,
-  type GeoPoint,
-} from '@/lib/discoveryLocation';
+import { milesBetween, type GeoPoint } from '@/lib/discoveryLocation';
 import { fetchFeedPosts } from './postsRead';
 
-export { DEFAULT_PITTSBURGH_COORDS };
 export type { GeoPoint };
 
 export interface DiscoverySalePost extends SalePost {
-  neighborhoodTag: string;
   distanceMiles: number;
 }
 
 export interface DiscoveryFeedResult {
-  neighborhood: string;
   listings: DiscoverySalePost[];
 }
 
-function enrichSalePostsForDiscovery(
+function storeHasGeo(seller: SalePost['seller']): seller is SalePost['seller'] & {
+  latitude: number;
+  longitude: number;
+} {
+  return (
+    seller.accountType === 'store' &&
+    seller.latitude !== null &&
+    seller.longitude !== null &&
+    Number.isFinite(seller.latitude) &&
+    Number.isFinite(seller.longitude)
+  );
+}
+
+function enrichStoreSalePostsForDiscovery(
   salePosts: SalePost[],
   userCoords: GeoPoint,
 ): DiscoverySalePost[] {
-  return salePosts.map((post) => {
-    const postCoords = coordinateFromLocation(post.seller.location) ?? DEFAULT_PITTSBURGH_COORDS;
-    const neighborhoodTag = resolveNeighborhood(postCoords);
-    const distanceMiles = milesBetween(userCoords, postCoords);
-    return {
-      ...post,
-      neighborhoodTag,
-      distanceMiles,
+  const out: DiscoverySalePost[] = [];
+  for (const post of salePosts) {
+    if (!storeHasGeo(post.seller)) continue;
+    const storePoint: GeoPoint = {
+      latitude: post.seller.latitude,
+      longitude: post.seller.longitude,
     };
-  });
+    out.push({
+      ...post,
+      distanceMiles: milesBetween(userCoords, storePoint),
+    });
+  }
+  return out;
 }
 
-function filterDiscoveryCandidates(
-  enriched: DiscoverySalePost[],
-  userNeighborhood: string,
-  radiusMiles: number,
-): DiscoverySalePost[] {
-  return radiusMiles <= 0
-    ? enriched.filter((post) => post.neighborhoodTag === userNeighborhood)
-    : enriched.filter((post) => post.distanceMiles <= radiusMiles);
+function filterByRadiusMiles(listings: DiscoverySalePost[], radiusMiles: number): DiscoverySalePost[] {
+  return listings.filter((post) => post.distanceMiles <= radiusMiles);
 }
 
-function resolveDiscoveryListingPool(
-  filtered: DiscoverySalePost[],
-  enriched: DiscoverySalePost[],
-): DiscoverySalePost[] {
-  return (filtered.length > 0 ? filtered : enriched).slice();
-}
-
-function sortDiscoveryListings(
-  listings: DiscoverySalePost[],
-  userNeighborhood: string,
-): DiscoverySalePost[] {
+function sortByDistanceThenId(listings: DiscoverySalePost[]): DiscoverySalePost[] {
   return [...listings].sort((a, b) => {
-    const aIsLocal = a.neighborhoodTag === userNeighborhood ? 1 : 0;
-    const bIsLocal = b.neighborhoodTag === userNeighborhood ? 1 : 0;
-
-    if (aIsLocal !== bIsLocal) return bIsLocal - aIsLocal;
-    if (Math.abs(a.distanceMiles - b.distanceMiles) > 0.05) {
-      return a.distanceMiles - b.distanceMiles;
-    }
-    return b.likes - a.likes;
+    const d = a.distanceMiles - b.distanceMiles;
+    if (Math.abs(d) > 1e-6) return d;
+    return a.id.localeCompare(b.id);
   });
 }
 
@@ -75,21 +61,12 @@ export async function fetchDiscoveryFeed(options: {
   radiusMiles: number;
 }): Promise<DiscoveryFeedResult> {
   const { userCoords, radiusMiles } = options;
-  const userNeighborhood = resolveNeighborhood(userCoords);
   const feed = await fetchFeedPosts();
 
   const salePosts = feed.filter((post): post is SalePost => post.type === 'sale');
+  const enriched = enrichStoreSalePostsForDiscovery(salePosts, userCoords);
+  const inRadius = filterByRadiusMiles(enriched, radiusMiles);
+  const listings = sortByDistanceThenId(inRadius);
 
-  const enriched = enrichSalePostsForDiscovery(salePosts, userCoords);
-
-  const filtered = filterDiscoveryCandidates(enriched, userNeighborhood, radiusMiles);
-
-  const pool = resolveDiscoveryListingPool(filtered, enriched);
-
-  const listings = sortDiscoveryListings(pool, userNeighborhood);
-
-  return {
-    neighborhood: userNeighborhood,
-    listings,
-  };
+  return { listings };
 }

--- a/Buyinz/supabase/postMappers.ts
+++ b/Buyinz/supabase/postMappers.ts
@@ -16,6 +16,8 @@ function timeAgo(dateStr: string): string {
 }
 
 function sellerFromUserRow(user: any): Seller {
+  const lat = user.latitude;
+  const lng = user.longitude;
   return {
     id: user.id,
     username: user.username,
@@ -26,6 +28,9 @@ function sellerFromUserRow(user: any): Seller {
     followers: 0,
     following: 0,
     posts: 0,
+    accountType: user.account_type === 'store' ? 'store' : 'user',
+    latitude: typeof lat === 'number' && Number.isFinite(lat) ? lat : null,
+    longitude: typeof lng === 'number' && Number.isFinite(lng) ? lng : null,
   };
 }
 

--- a/Buyinz/supabase/postsRead.ts
+++ b/Buyinz/supabase/postsRead.ts
@@ -43,7 +43,7 @@ export async function fetchSaleListingById(id: string): Promise<SalePost | null>
   return mapRowToPost(data) as SalePost;
 }
 
-/** Deletes the listing and related conversations/messages; server enforces seller ownership. */
+/** Deletes the listing and related conversations; server enforces seller ownership. */
 export async function deleteOwnSaleListing(listingId: string): Promise<void> {
   const { error } = await supabase.rpc('delete_own_sale_listing', {
     p_listing_id: listingId,

--- a/Buyinz/supabase/queries.ts
+++ b/Buyinz/supabase/queries.ts
@@ -5,8 +5,8 @@
 export type { PublicUserProfile } from './usersRead';
 export { fetchUserPublicProfileById } from './usersRead';
 
-export { DEFAULT_PITTSBURGH_COORDS } from './discoveryFeed';
-export type { GeoPoint } from './discoveryFeed';
+export { DEFAULT_CMU_COORDS } from '@/lib/discoveryLocation';
+export type { GeoPoint } from '@/lib/discoveryLocation';
 
 export type { DiscoverySalePost, DiscoveryFeedResult } from './discoveryFeed';
 


### PR DESCRIPTION
Closes #89 

Summary
Discover shows only sale listings from store accounts that have latitude and longitude in Supabase. Results are sorted by distance from the shopper’s current location and filtered by radius (5 / 10 / 20 mi, default 10 mi). Neighborhood-based sorting, filtering, and copy are removed. If foreground location permission is denied or location fails, distance and sorting use fixed CMU campus coordinates.

Implementation notes
Seller / postMappers: Map account_type, latitude, and longitude from joined users; non-finite coordinates become null.
discoveryFeed: Store-only listings with valid coordinates; haversine distance on the client; radius filter; sort by distance, then listing id; no neighborhood fallback pool.
lib/discoveryLocation: DEFAULT_CMU_COORDS and milesBetween only (Pittsburgh/neighborhood helpers removed).
queries: Re-export DEFAULT_CMU_COORDS for the app.
explore: CMU baseline when permission denied or errors; updated subtitle and default radius behavior.
Mock data: Sellers extended with accountType and geo fields for local/dev consistency.
Database
No new migration: existing policies already allow reading the joined user fields needed for this feed.

Verification
Run the app: Discover with location granted vs denied; confirm store-only feed, distances, and radius chips.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated default search location center and permission failure fallback coordinates.
  * Set initial search radius to 10 miles by default.
  * Changed listings to sort by distance instead of neighborhood proximity.
  * Removed neighborhood labels from the discovery feed; now displays "Store listings sorted by distance" instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->