### PR TITLE
UI and small feature improvements

### DIFF
--- a/Buyinz/app/(tabs)/explore.tsx
+++ b/Buyinz/app/(tabs)/explore.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useIsFocused } from '@react-navigation/native';
 import {
   ActivityIndicator,
   FlatList,
@@ -55,6 +56,7 @@ export default function ExploreTabScreen() {
   const colors = Colors[scheme];
   const insets = useSafeAreaInsets();
   const { user } = useAuth();
+  const isFocused = useIsFocused();
 
   const [activeRadius, setActiveRadius] = useState(DEFAULT_RADIUS_MILES);
   const [sortMode, setSortMode] = useState<ExploreSortMode>('distance');
@@ -130,24 +132,19 @@ export default function ExploreTabScreen() {
     };
   }, [user]);
 
-  useEffect(() => {
+  const loadExplore = useCallback(() => {
     if (!user || user.account_type === 'store') return;
-    let mounted = true;
     setLoading(true);
-
     fetchNearbyStoresForExplore({ userCoords, radiusMiles: activeRadius })
-      .then((list) => {
-        if (mounted) setRawStores(list);
-      })
+      .then(setRawStores)
       .catch(console.error)
-      .finally(() => {
-        if (mounted) setLoading(false);
-      });
-
-    return () => {
-      mounted = false;
-    };
+      .finally(() => setLoading(false));
   }, [user, activeRadius, userCoords]);
+
+  useEffect(() => {
+    if (!isFocused) return;
+    loadExplore();
+  }, [isFocused, loadExplore]);
 
   if (!user) {
     return <Redirect href="/(tabs)/profile" />;

--- a/Buyinz/app/(tabs)/profile.tsx
+++ b/Buyinz/app/(tabs)/profile.tsx
@@ -16,6 +16,7 @@ import type { SalePost } from '@/data/mockData';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/lib/supabase';
 import {
+  fetchFollowingStoreCount,
   fetchNewSaleListingsCountLast24hBatch,
   fetchStoreFollowerCountsBatch,
   fetchUserPublicProfileById,
@@ -35,10 +36,11 @@ export default function ProfileScreen() {
   const [listingsLoading, setListingsLoading] = useState(true);
   const [newItemsLast24h, setNewItemsLast24h] = useState<number | undefined>(undefined);
   const [followerCount, setFollowerCount] = useState<number | undefined>(undefined);
+  const [followingCount, setFollowingCount] = useState(0);
   const [storeAddressLine, setStoreAddressLine] = useState<string | null>(null);
 
   const loadListings = useCallback(() => {
-    if (!user?.id) {
+    if (!user?.id || user.account_type === 'user') {
       setUserListings([]);
       setListingsLoading(false);
       return;
@@ -51,17 +53,38 @@ export default function ProfileScreen() {
         setUserListings([]);
       })
       .finally(() => setListingsLoading(false));
-  }, [user?.id]);
+  }, [user?.id, user?.account_type]);
 
   useFocusEffect(
     useCallback(() => {
-      loadListings();
-      if (!user?.id || user.account_type !== 'store') {
+      if (!user?.id) {
+        setUserListings([]);
+        setListingsLoading(false);
         setNewItemsLast24h(undefined);
         setFollowerCount(undefined);
+        setFollowingCount(0);
         setStoreAddressLine(null);
         return;
       }
+
+      if (user.account_type === 'user') {
+        setUserListings([]);
+        setListingsLoading(false);
+        setNewItemsLast24h(undefined);
+        setFollowerCount(undefined);
+        setStoreAddressLine(null);
+        let cancelled = false;
+        fetchFollowingStoreCount()
+          .then((n) => {
+            if (!cancelled) setFollowingCount(n);
+          })
+          .catch(console.error);
+        return () => {
+          cancelled = true;
+        };
+      }
+
+      loadListings();
       let cancelled = false;
       fetchUserPublicProfileById(user.id)
         .then((p) => {
@@ -133,6 +156,9 @@ export default function ProfileScreen() {
         avatarUrl={user.avatar_url}
         postsCount={userListings.length}
         followerCount={user.account_type === 'store' ? followerCount : undefined}
+        showFollowingStatOnly={user.account_type === 'user'}
+        followingCount={user.account_type === 'user' ? followingCount : undefined}
+        hideListingsSection={user.account_type === 'user'}
         listings={userListings}
         listingsLoading={listingsLoading}
         onPressListing={(listingId) =>

--- a/Buyinz/app/create-listing.tsx
+++ b/Buyinz/app/create-listing.tsx
@@ -134,7 +134,10 @@ export default function CreateListingScreen() {
         </View>
 
         <View style={styles.section}>
-          <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>Title</Text>
+          <Text style={[styles.sectionLabel, { color: colors.textSecondary }]}>
+            Title{' '}
+            <Text style={{ fontWeight: '400', textTransform: 'none' }}>(optional)</Text>
+          </Text>
           <TextInput
             style={[styles.input, { backgroundColor: colors.card, borderColor: colors.border, color: colors.text }]}
             placeholder="What are you selling?"

--- a/Buyinz/app/listing/[id].tsx
+++ b/Buyinz/app/listing/[id].tsx
@@ -140,8 +140,8 @@ export default function ListingDetailScreen() {
       return;
     }
     const showTrash = user?.id === post.seller.id && listingSource === 'db';
-    const title =
-      post.title.length > 32 ? `${post.title.slice(0, 32)}…` : post.title;
+    const headline = post.title.trim().length > 0 ? post.title : 'Listing';
+    const title = headline.length > 32 ? `${headline.slice(0, 32)}…` : headline;
     navigation.setOptions({
       title,
       headerLeft,
@@ -245,7 +245,9 @@ export default function ListingDetailScreen() {
 
         <View style={styles.content}>
           <View style={styles.titleRow}>
-            <Text style={[styles.title, { color: colors.text }]}>{post.title}</Text>
+            <Text style={[styles.title, { color: colors.text }]}>
+              {post.title.trim().length > 0 ? post.title : 'Listing'}
+            </Text>
             {post.price != null ? (
               <Text style={[styles.price, { color: Brand.primary }]}>${post.price}</Text>
             ) : null}
@@ -258,11 +260,15 @@ export default function ListingDetailScreen() {
             <Image source={{ uri: post.seller.avatar }} style={[styles.avatar, { borderColor: colors.border }]} />
             <View style={styles.sellerInfo}>
               <Text style={[styles.sellerName, { color: colors.text }]}>{post.seller.displayName}</Text>
-              <Text style={[styles.sellerMeta, { color: colors.textSecondary }]}>@{post.seller.username}</Text>
+              <Text style={[styles.sellerMeta, { color: colors.textSecondary }]} numberOfLines={1}>
+                @{post.seller.username} · {post.createdAt}
+              </Text>
             </View>
           </Pressable>
 
-          <Text style={[styles.description, { color: colors.text }]}>{post.description}</Text>
+          {post.description.trim().length > 0 ? (
+            <Text style={[styles.description, { color: colors.text }]}>{post.description}</Text>
+          ) : null}
         </View>
       </ScrollView>
     </View>

--- a/Buyinz/components/feed/SalePostCard.tsx
+++ b/Buyinz/components/feed/SalePostCard.tsx
@@ -130,7 +130,7 @@ export function SalePostCard({ post, cardWidth, fill, newItemsLast24h }: Props) 
             onPress={() => router.push(`/listing/${post.id}`, { withAnchor: true })}
           >
             <Text style={[styles.title, { color: colors.text }]} numberOfLines={1}>
-              {post.title}
+              {post.title.trim().length > 0 ? post.title : 'Listing'}
             </Text>
             {post.price != null ? (
               <View style={styles.priceBadge}>

--- a/Buyinz/components/profile/ProfileBody.tsx
+++ b/Buyinz/components/profile/ProfileBody.tsx
@@ -39,6 +39,11 @@ export type ProfileBodyProps = {
   postsCount: number;
   /** When set (e.g. store profiles), show Followers stat alongside Posts. */
   followerCount?: number;
+  /** Shopper self-profile: show only this stat (omit Posts / Followers and listings grid). */
+  showFollowingStatOnly?: boolean;
+  followingCount?: number;
+  /** Hide listings grid (e.g. shopper accounts have no sale listings). */
+  hideListingsSection?: boolean;
   listings: SalePost[];
   listingsLoading: boolean;
   onPressListing: (listingId: string) => void;
@@ -58,6 +63,9 @@ export function ProfileBody({
   avatarUrl,
   postsCount,
   followerCount,
+  showFollowingStatOnly,
+  followingCount,
+  hideListingsSection,
   listings,
   listingsLoading,
   onPressListing,
@@ -87,8 +95,14 @@ export function ProfileBody({
         <View style={styles.avatarStatsRow}>
           <Image source={{ uri }} style={[styles.avatar, { borderColor: colors.border }]} />
           <View style={styles.statsRow}>
-            <Stat label="Posts" value={postsCount} />
-            {followerCount !== undefined ? <Stat label="Followers" value={followerCount} /> : null}
+            {showFollowingStatOnly ? (
+              <Stat label="Following" value={followingCount ?? 0} />
+            ) : (
+              <>
+                <Stat label="Posts" value={postsCount} />
+                {followerCount !== undefined ? <Stat label="Followers" value={followerCount} /> : null}
+              </>
+            )}
           </View>
         </View>
 
@@ -115,47 +129,51 @@ export function ProfileBody({
         {footerBeforeGrid}
       </View>
 
-      <View style={[styles.gridHeader, { borderTopColor: colors.border }]}>
-        <Ionicons name="grid-outline" size={20} color={colors.text} />
-      </View>
+      {!hideListingsSection ? (
+        <>
+          <View style={[styles.gridHeader, { borderTopColor: colors.border }]}>
+            <Ionicons name="grid-outline" size={20} color={colors.text} />
+          </View>
 
-      {listingsLoading ? (
-        <View style={{ paddingVertical: 32, alignItems: 'center' }}>
-          <Text style={{ color: colors.tabIconDefault }}>Loading listings…</Text>
-        </View>
-      ) : listings.length === 0 ? (
-        <View style={{ paddingHorizontal: 24, paddingVertical: 32, alignItems: 'center' }}>
-          <Ionicons name="images-outline" size={40} color={colors.tabIconDefault} style={{ marginBottom: 12 }} />
-          <Text style={{ color: colors.text, fontWeight: '600', marginBottom: 6 }}>No listings yet</Text>
-          <Text style={{ color: colors.tabIconDefault, textAlign: 'center', fontSize: 14 }}>
-            {listingsEmptyVariant === 'self'
-              ? 'When you post items for sale, they will show here in a grid.'
-              : 'This user has not posted any listings yet.'}
-          </Text>
-        </View>
-      ) : (
-        <View style={styles.gridContainer}>
-          {paddedGridItems.map((listing, i) => (
-            <View
-              key={listing ? listing.id : `grid-pad-${i}`}
-              style={[styles.gridItem, { width: PROFILE_GRID_ITEM_SIZE, height: PROFILE_GRID_ITEM_SIZE }]}
-            >
-              {listing ? (
-                <Pressable style={{ flex: 1 }} onPress={() => onPressListing(listing.id)}>
-                  <Image
-                    source={{
-                      uri: listing.images[0] ?? 'https://via.placeholder.com/150',
-                    }}
-                    style={styles.gridImage}
-                  />
-                </Pressable>
-              ) : (
-                <View style={[styles.gridImage, { backgroundColor: colors.muted }]} />
-              )}
+          {listingsLoading ? (
+            <View style={{ paddingVertical: 32, alignItems: 'center' }}>
+              <Text style={{ color: colors.tabIconDefault }}>Loading listings…</Text>
             </View>
-          ))}
-        </View>
-      )}
+          ) : listings.length === 0 ? (
+            <View style={{ paddingHorizontal: 24, paddingVertical: 32, alignItems: 'center' }}>
+              <Ionicons name="images-outline" size={40} color={colors.tabIconDefault} style={{ marginBottom: 12 }} />
+              <Text style={{ color: colors.text, fontWeight: '600', marginBottom: 6 }}>No listings yet</Text>
+              <Text style={{ color: colors.tabIconDefault, textAlign: 'center', fontSize: 14 }}>
+                {listingsEmptyVariant === 'self'
+                  ? 'When you post items for sale, they will show here in a grid.'
+                  : 'This user has not posted any listings yet.'}
+              </Text>
+            </View>
+          ) : (
+            <View style={styles.gridContainer}>
+              {paddedGridItems.map((listing, i) => (
+                <View
+                  key={listing ? listing.id : `grid-pad-${i}`}
+                  style={[styles.gridItem, { width: PROFILE_GRID_ITEM_SIZE, height: PROFILE_GRID_ITEM_SIZE }]}
+                >
+                  {listing ? (
+                    <Pressable style={{ flex: 1 }} onPress={() => onPressListing(listing.id)}>
+                      <Image
+                        source={{
+                          uri: listing.images[0] ?? 'https://via.placeholder.com/150',
+                        }}
+                        style={styles.gridImage}
+                      />
+                    </Pressable>
+                  ) : (
+                    <View style={[styles.gridImage, { backgroundColor: colors.muted }]} />
+                  )}
+                </View>
+              ))}
+            </View>
+          )}
+        </>
+      ) : null}
     </ScrollView>
   );
 }

--- a/Buyinz/lib/listings.ts
+++ b/Buyinz/lib/listings.ts
@@ -38,10 +38,9 @@ export function priceStringToDbValue(price: string): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
-/** A listing is valid as long as it has at least one photo and a title. Price is optional. */
+/** A listing is valid as long as it has at least one photo. Title and price are optional. */
 export function isDraftValid(draft: ListingDraft): boolean {
   if (draft.images.length === 0) return false;
-  if (draft.title.trim().length === 0) return false;
   const pt = draft.price.trim();
   if (pt.length > 0) {
     const n = parseFloat(pt);

--- a/Buyinz/supabase/migrations/20260419190000_posts_title_nullable.sql
+++ b/Buyinz/supabase/migrations/20260419190000_posts_title_nullable.sql
@@ -1,0 +1,6 @@
+-- Sale listing titles are optional (stores may omit).
+
+alter table public.posts
+  alter column title drop not null;
+
+comment on column public.posts.title is 'Sale listing headline; NULL when omitted.';

--- a/Buyinz/supabase/migrations/20260420120000_posts_category_check_listing_categories.sql
+++ b/Buyinz/supabase/migrations/20260420120000_posts_category_check_listing_categories.sql
@@ -1,0 +1,13 @@
+-- Create-listing uses Tops, Bottoms, Accessories, Other (see lib/listings.ts).
+-- Older DB check constraints may omit these and reject valid inserts.
+
+alter table public.posts drop constraint if exists posts_category_check;
+
+-- Non-blank category when present; allows Tops, Bottoms, Accessories, Other and legacy labels.
+alter table public.posts add constraint posts_category_check check (
+  length(trim(category)) > 0
+  and length(category) <= 80
+);
+
+comment on constraint posts_category_check on public.posts is
+  'Category must be a non-empty string up to 80 chars; app restricts allowed values.';

--- a/Buyinz/supabase/postMappers.ts
+++ b/Buyinz/supabase/postMappers.ts
@@ -34,12 +34,21 @@ function sellerFromUserRow(user: any): Seller {
   };
 }
 
+/** Maps DB description to UI; treats legacy placeholder default as empty. */
+function descriptionForDisplay(raw: unknown): string {
+  if (raw == null) return '';
+  const s = String(raw).trim();
+  if (s.length === 0) return '';
+  if (s.toLowerCase() === 'listing') return '';
+  return s;
+}
+
 function buildPostBase(row: any, seller: Seller) {
   return {
     id: row.id,
     seller,
-    title: row.title,
-    description: row.description ?? '',
+    title: row.title ?? '',
+    description: descriptionForDisplay(row.description),
     category: row.category,
     likes: 0,
     comments: 0,

--- a/Buyinz/supabase/postsInsert.ts
+++ b/Buyinz/supabase/postsInsert.ts
@@ -53,12 +53,14 @@ export async function uploadListingImages(images: ImageAsset[]): Promise<string[
 export async function insertPost(draft: ListingDraft, userId?: string): Promise<string> {
   const imageUrls = await uploadListingImages(draft.images);
 
+  const titleTrimmed = draft.title.trim();
   const { data, error } = await supabase
     .from('posts')
     .insert({
       user_id: userId || DEFAULT_MOCK_USER_ID,
       type: 'sale',
-      title: draft.title,
+      title: titleTrimmed.length > 0 ? titleTrimmed : null,
+      description: null,
       category: draft.category,
       price: priceStringToDbValue(draft.price),
       images: imageUrls,

--- a/Buyinz/supabase/queries.ts
+++ b/Buyinz/supabase/queries.ts
@@ -31,6 +31,7 @@ export { fetchNewSaleListingsCountLast24hBatch } from './newItemsCount';
 export type { FollowedStoreForHome } from './storeFollows';
 export {
   fetchFollowedStoresForHome,
+  fetchFollowingStoreCount,
   followStore,
   unfollowStore,
   isFollowingStore,

--- a/Buyinz/supabase/storeFollows.ts
+++ b/Buyinz/supabase/storeFollows.ts
@@ -19,6 +19,22 @@ type FollowerCountRow = { store_id: string; follower_count: number | string };
 /**
  * Followed stores for the signed-in shopper, with 24h new listing counts.
  */
+/** Number of stores the signed-in shopper follows. */
+export async function fetchFollowingStoreCount(): Promise<number> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user?.id) return 0;
+
+  const { count, error } = await supabase
+    .from('store_follows')
+    .select('*', { count: 'exact', head: true })
+    .eq('follower_id', user.id);
+
+  if (error) throw error;
+  return count ?? 0;
+}
+
 export async function fetchFollowedStoresForHome(): Promise<FollowedStoreForHome[]> {
   const {
     data: { user },

--- a/Buyinz/tests/listings.test.ts
+++ b/Buyinz/tests/listings.test.ts
@@ -65,7 +65,7 @@ describe('priceStringToDbValue', () => {
 });
 
 describe('isDraftValid', () => {
-  it('returns true when photos and title are present', () => {
+  it('returns true when at least one photo is present', () => {
     expect(isDraftValid(minimalValidDraft())).toBe(true);
   });
 
@@ -73,9 +73,9 @@ describe('isDraftValid', () => {
     expect(isDraftValid(minimalValidDraft({ images: [] }))).toBe(false);
   });
 
-  it('requires non-empty trimmed title', () => {
-    expect(isDraftValid(minimalValidDraft({ title: '' }))).toBe(false);
-    expect(isDraftValid(minimalValidDraft({ title: '   ' }))).toBe(false);
+  it('allows empty or whitespace-only title', () => {
+    expect(isDraftValid(minimalValidDraft({ title: '' }))).toBe(true);
+    expect(isDraftValid(minimalValidDraft({ title: '   ' }))).toBe(true);
   });
 
   it('treats price as optional', () => {

--- a/Buyinz/tests/postMappers.test.ts
+++ b/Buyinz/tests/postMappers.test.ts
@@ -206,6 +206,11 @@ describe('mapRowToPost base (buildPostBase)', () => {
     expect(b.hashtags).toEqual([]);
   });
 
+  it('maps legacy placeholder description "Listing" to empty string', () => {
+    const post = mapRowToPost(isoRowForBase({ description: 'Listing' }));
+    expect(post.description).toBe('');
+  });
+
   it('maps id, title, category, likes, comments, liked, and createdAt from base', () => {
     const post = mapRowToPost(
       isoRowForBase({
@@ -365,6 +370,21 @@ describe('mapRowToPost type branches', () => {
     expect(sale.images).toEqual([]);
     expect(sale.price).toBeNull();
     expect(sale.sold).toBe(false);
+  });
+
+  it('sale branch: maps null title to empty string', () => {
+    const row = {
+      id: 'sale-null-title',
+      type: 'sale' as const,
+      title: null,
+      category: 'Other' as const,
+      created_at,
+      users,
+    };
+
+    const post = mapRowToPost(row);
+    const sale = post as SalePost;
+    expect(sale.title).toBe('');
   });
 
   it('sale branch: maps explicit zero price', () => {

--- a/Buyinz/tests/postsInsert-tests.ts
+++ b/Buyinz/tests/postsInsert-tests.ts
@@ -279,6 +279,7 @@ describe('postsInsert', () => {
         user_id: '11111111-1111-1111-1111-111111111111',
         type: 'sale',
         title: 'Desk',
+        description: null,
         category: 'Tops',
         price: 45,
         images: ['https://example.test/object/1700000000000-zzzj7c.jpg'],
@@ -293,6 +294,26 @@ describe('postsInsert', () => {
       expect(mockInsert).toHaveBeenCalledWith(
         expect.objectContaining({
           price: null,
+        }),
+      );
+    });
+
+    it('inserts null title when draft title is empty', async () => {
+      await insertPost(baseDraft({ title: '' }));
+
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: null,
+        }),
+      );
+    });
+
+    it('inserts null title when draft title is whitespace only', async () => {
+      await insertPost(baseDraft({ title: '   ' }));
+
+      expect(mockInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: null,
         }),
       );
     });


### PR DESCRIPTION
## Summary

Small UX and data fixes for listings, Explore, shopper profiles, and Supabase constraints.

## Changes

### Listings
- **Optional titles**: `posts.title` nullable; create flow allows empty title; UI falls back to “Listing” only for **title** where needed; inserts omit title when blank.
- **Descriptions**: Inserts set `description: null` so DB defaults don’t fill placeholder text; mapper strips legacy literal `Listing`; listing detail hides the description block when empty.
- **Categories**: Replaces strict `posts_category_check` with a length/non-blank check so create-listing values (e.g. **Accessories**, **Tops**, **Bottoms**) aren’t rejected by the DB.

### Explore & tabs
- **Explore**: Refetches nearby stores when the tab is focused (and when radius/location inputs change) so followed stores disappear from the list after you follow them elsewhere.

### Shopper profile
- **Self profile (`account_type` user)**: Shows **Following** count only; hides posts count and listings grid/empty states.

### Listing detail
- Shows relative posted time next to `@username` on the detail screen.

### Supabase migrations (apply on project)
- `posts` title nullable, category check update (see migration files in `supabase/migrations/`).

## Testing
- `npm test` / `npm run lint` (as run locally).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User accounts now display following store count on their profile.

* **Bug Fixes**
  * Listings with empty or missing titles now display "Listing" as a fallback.
  * Empty descriptions are no longer shown.
  * Title field is now optional when creating listings.

* **Improvements**
  * User and store account profiles display customized layouts and information based on account type.
  * Enhanced navigation and content loading performance for the explore screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->