### PR TITLE
bug fix: invalid zipcodes

### DIFF
--- a/Buyinz/app/create-profile.tsx
+++ b/Buyinz/app/create-profile.tsx
@@ -3,6 +3,8 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import {
   normalizeUsStateRegion,
+  getPittsburghZipValidationError,
+  sanitizeUsZipInput,
   validateUsStoreAddressFormat,
 } from '@/lib/addressValidation';
 import {
@@ -290,6 +292,11 @@ export default function CreateProfileScreen() {
         throw new Error('Choose Shopper or Store.');
       }
 
+      const zipError = getPittsburghZipValidationError(postalCode);
+      if (zipError && accountKind === 'store') {
+        throw new Error(zipError);
+      }
+
       const u = normalizeUsername(username);
       if (!u) {
         throw new Error('Please choose a username.');
@@ -430,6 +437,9 @@ export default function CreateProfileScreen() {
       postal_code: postalCode,
     }).ok;
 
+  const zipValidationError =
+    accountKind === 'store' ? getPittsburghZipValidationError(postalCode) : null;
+
   const coreFilled =
     accountKind === 'user'
       ? userCoreFilled
@@ -476,6 +486,14 @@ export default function CreateProfileScreen() {
       );
     }
     return null;
+  };
+
+  const zipHint = () => {
+    if (!postalCode.trim()) return null;
+    if (!zipValidationError) return null;
+    return (
+      <Text style={[styles.hint, { color: '#ef4444' }]}>{zipValidationError}</Text>
+    );
   };
 
   const fieldErr = (empty: boolean) =>
@@ -765,14 +783,16 @@ export default function CreateProfileScreen() {
                   style={[
                     styles.input,
                     { color: colors.text, borderColor: colors.border },
-                    fieldErr(!postalCode.trim()),
+                    fieldErr(!postalCode.trim() || !!zipValidationError),
                   ]}
-                  placeholder="ZIP (5 digits or ZIP+4)"
+                  placeholder="Pittsburgh ZIP (5 digits or ZIP+4)"
                   placeholderTextColor={colors.tabIconDefault}
                   value={postalCode}
-                  onChangeText={setPostalCode}
-                  keyboardType="numeric"
+                  onChangeText={(text) => setPostalCode(sanitizeUsZipInput(text))}
+                  keyboardType="default"
+                  maxLength={10}
                 />
+                {zipHint()}
               </>
             )}
 

--- a/Buyinz/lib/addressValidation.ts
+++ b/Buyinz/lib/addressValidation.ts
@@ -16,10 +16,31 @@ export function normalizeUsZipToFiveDigits(input: string): string {
   return digits.length >= 5 ? digits.slice(0, 5) : digits;
 }
 
+/** Strip invalid ZIP characters while preserving digits and a single hyphen. */
+export function sanitizeUsZipInput(input: string): string {
+  return input.replace(/[^\d-]/g, '').slice(0, 10);
+}
+
 export function isValidUsZipFormat(input: string): boolean {
   const t = input.trim();
   if (!t) return false;
   return US_ZIP_REGEX.test(t);
+}
+
+export function getPittsburghZipValidationError(
+  input: string,
+): string | null {
+  const t = input.trim();
+  if (!isValidUsZipFormat(t)) {
+    return 'Enter a valid U.S. ZIP code (5 digits, optional +4).';
+  }
+
+  const zip5 = normalizeUsZipToFiveDigits(t);
+  if (!zip5.startsWith('152')) {
+    return 'Use a Pittsburgh ZIP code.';
+  }
+
+  return null;
 }
 
 /** Uppercase 2-letter state/region code. */
@@ -72,10 +93,11 @@ export function validateUsStoreAddressFormat(
   }
 
   const zip = parts.postal_code.trim();
-  if (!isValidUsZipFormat(zip)) {
+  const zipError = getPittsburghZipValidationError(zip);
+  if (zipError) {
     return {
       ok: false,
-      message: 'Enter a valid U.S. ZIP code (5 digits, optional +4).',
+      message: zipError,
     };
   }
 

--- a/Buyinz/tests/addressValidation.test.ts
+++ b/Buyinz/tests/addressValidation.test.ts
@@ -1,8 +1,10 @@
 import {
+  getPittsburghZipValidationError,
   isValidUsStateCode,
   isValidUsZipFormat,
   normalizeUsStateRegion,
   normalizeUsZipToFiveDigits,
+  sanitizeUsZipInput,
   validateUsStoreAddressFormat,
 } from '../lib/addressValidation';
 
@@ -10,6 +12,12 @@ describe('normalizeUsZipToFiveDigits', () => {
   it('returns first five digits', () => {
     expect(normalizeUsZipToFiveDigits('15213-1234')).toBe('15213');
     expect(normalizeUsZipToFiveDigits('15213')).toBe('15213');
+  });
+});
+
+describe('sanitizeUsZipInput', () => {
+  it('keeps only digits and hyphen for ZIP entry', () => {
+    expect(sanitizeUsZipInput('15a213-12b34')).toBe('15213-1234');
   });
 });
 
@@ -23,6 +31,17 @@ describe('isValidUsZipFormat', () => {
     expect(isValidUsZipFormat('1234')).toBe(false);
     expect(isValidUsZipFormat('')).toBe(false);
     expect(isValidUsZipFormat('1521-1234')).toBe(false);
+  });
+});
+
+describe('getPittsburghZipValidationError', () => {
+  it('accepts Pittsburgh ZIPs', () => {
+    expect(getPittsburghZipValidationError('15213')).toBeNull();
+    expect(getPittsburghZipValidationError('15213-1234')).toBeNull();
+  });
+
+  it('rejects non-Pittsburgh ZIPs', () => {
+    expect(getPittsburghZipValidationError('15120')).toMatch(/Pittsburgh/i);
   });
 });
 
@@ -50,6 +69,17 @@ describe('validateUsStoreAddressFormat', () => {
         postal_code: '15213',
       }).ok,
     ).toBe(true);
+  });
+
+  it('rejects a non-Pittsburgh ZIP', () => {
+    const r = validateUsStoreAddressFormat({
+      address_line1: '1 Main St',
+      city: 'Pittsburgh',
+      region: 'PA',
+      postal_code: '15120',
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.message).toMatch(/Pittsburgh/i);
   });
 
   it('fails bad ZIP', () => {

--- a/Buyinz/tests/storeProfileLocation.test.ts
+++ b/Buyinz/tests/storeProfileLocation.test.ts
@@ -125,6 +125,19 @@ describe('Store profile & location (user story)', () => {
         }).ok,
       ).toBe(true);
     });
+
+    it('rejects ZIP codes outside Pittsburgh', () => {
+      const r = validateUsStoreAddressFormat({
+        address_line1: '5000 Forbes Ave',
+        city: 'Pittsburgh',
+        region: 'PA',
+        postal_code: '15120',
+      });
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.message).toMatch(/Pittsburgh/i);
+      }
+    });
   });
 
   describe('normalizeUsStateRegion', () => {


### PR DESCRIPTION
Fixes #130 

ZIP input now strips invalid characters, only allows Pittsburgh ZIPs, and blocks save when the ZIP is outside the Pittsburgh 152xx range in app/create-profile.tsx and lib/addressValidation.ts.
Store profile validation now rejects non-Pittsburgh ZIPs before geocoding/saving.
Added tests for ZIP sanitization and Pittsburgh-only validation in tests/addressValidation.test.ts and tests/storeProfileLocation.test.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Store profile ZIP code validation now enforces Pittsburgh area requirements
  * ZIP input field enhanced with auto-sanitization, character limits, and improved error messaging

* **Tests**
  * Added comprehensive address validation test coverage for Pittsburgh ZIP constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->