### PR TITLE
bug fix: listing price validation

### DIFF
--- a/Buyinz/app/create-listing.tsx
+++ b/Buyinz/app/create-listing.tsx
@@ -21,6 +21,7 @@ import { PhotoPicker } from '@/components/create/PhotoPicker';
 import {
   EMPTY_DRAFT,
   isDraftValid,
+  getListingPriceValidationError,
   submitListing,
   type ImageAsset,
   type ListingDraft,
@@ -46,6 +47,7 @@ export default function CreateListingScreen() {
   }
 
   const canSubmit = isDraftValid(draft);
+  const priceValidationError = getListingPriceValidationError(draft.price);
 
   const update = <K extends keyof ListingDraft>(key: K, value: ListingDraft[K]) =>
     setDraft((d) => ({ ...d, [key]: value }));
@@ -123,6 +125,14 @@ export default function CreateListingScreen() {
               maxLength={8}
             />
           </View>
+          {priceValidationError ? (
+            <Text style={[styles.priceError, { color: '#ef4444' }]}>
+              {priceValidationError}
+            </Text>
+          ) : null}
+          <Text style={[styles.priceHelp, { color: colors.textSecondary }]}>
+            Price must be between $0 and $10,000 with up to 2 decimal places.
+          </Text>
         </View>
       </ScrollView>
 
@@ -210,6 +220,16 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     fontFamily: Fonts.sans,
     paddingVertical: 12,
+  },
+  priceError: {
+    marginTop: 8,
+    fontSize: 13,
+    fontFamily: Fonts.sans,
+  },
+  priceHelp: {
+    marginTop: 4,
+    fontSize: 12,
+    fontFamily: Fonts.sans,
   },
   bottomBar: {
     position: 'absolute',

--- a/Buyinz/lib/listingDraft.ts
+++ b/Buyinz/lib/listingDraft.ts
@@ -1,5 +1,10 @@
 /** Shared listing draft types + price parsing — imported by `lib/listings` and `supabase/postsInsert` without a barrel cycle. */
 
+export const LISTING_PRICE_MIN = 0;
+export const LISTING_PRICE_MAX = 10_000;
+const LISTING_PRICE_REGEX = /^(?:0|[1-9]\d*)(?:\.\d{1,2})?$/;
+const LISTING_PRICE_MAX_LABEL = '10,000';
+
 export interface ImageAsset {
   uri: string;
   width: number;
@@ -12,13 +17,41 @@ export interface ListingDraft {
   price: string;
 }
 
+export function getListingPriceValidationError(price: string): string | null {
+  const t = price.trim();
+  if (t.length === 0) return null;
+  if (!LISTING_PRICE_REGEX.test(t)) {
+    return 'Enter a valid price with up to 2 decimal places.';
+  }
+
+  const n = Number(t);
+  if (!Number.isFinite(n)) {
+    return 'Enter a valid price.';
+  }
+  if (n < LISTING_PRICE_MIN) {
+    return `Price must be at least $${LISTING_PRICE_MIN}.`;
+  }
+  if (n > LISTING_PRICE_MAX) {
+    return `Price must be $${LISTING_PRICE_MAX_LABEL} or less.`;
+  }
+
+  return null;
+}
+
+export function validateListingPrice(price: string): void {
+  const message = getListingPriceValidationError(price);
+  if (message) {
+    throw new Error(message);
+  }
+}
+
 /**
  * Maps draft price field to DB: empty → null (no price), valid number including 0 → stored as-is.
- * Non-numeric input when non-empty is invalid for submit (see isDraftValid).
+ * Non-numeric input when non-empty is invalid for submit (see validateListingPrice).
  */
 export function priceStringToDbValue(price: string): number | null {
   const t = price.trim();
   if (t.length === 0) return null;
-  const n = parseFloat(t);
-  return Number.isFinite(n) ? n : null;
+  if (getListingPriceValidationError(t)) return null;
+  return Number(t);
 }

--- a/Buyinz/lib/listings.ts
+++ b/Buyinz/lib/listings.ts
@@ -1,8 +1,9 @@
 import { insertPost } from '@/supabase/queries';
 import type { ListingDraft } from './listingDraft';
+import { getListingPriceValidationError } from './listingDraft';
 
 export type { ImageAsset, ListingDraft } from './listingDraft';
-export { priceStringToDbValue } from './listingDraft';
+export { priceStringToDbValue, getListingPriceValidationError } from './listingDraft';
 
 export const EMPTY_DRAFT: ListingDraft = {
   images: [],
@@ -15,12 +16,7 @@ export const MAX_PHOTOS = 5;
 /** A listing is valid as long as it has at least one photo. Title and price are optional. */
 export function isDraftValid(draft: ListingDraft): boolean {
   if (draft.images.length === 0) return false;
-  const pt = draft.price.trim();
-  if (pt.length > 0) {
-    const n = parseFloat(pt);
-    if (!Number.isFinite(n) || n < 0) return false;
-  }
-  return true;
+  return getListingPriceValidationError(draft.price) === null;
 }
 
 export async function submitListing(

--- a/Buyinz/supabase/postsInsert.ts
+++ b/Buyinz/supabase/postsInsert.ts
@@ -1,6 +1,6 @@
 import { supabase } from './client';
 import type { ListingDraft, ImageAsset } from '@/lib/listingDraft';
-import { priceStringToDbValue } from '@/lib/listingDraft';
+import { priceStringToDbValue, validateListingPrice } from '@/lib/listingDraft';
 
 const DEFAULT_MOCK_USER_ID = '11111111-1111-1111-1111-111111111111';
 const IMAGE_BUCKET = 'listing-images';
@@ -51,6 +51,7 @@ export async function uploadListingImages(images: ImageAsset[]): Promise<string[
 }
 
 export async function insertPost(draft: ListingDraft, userId?: string): Promise<string> {
+  validateListingPrice(draft.price);
   const imageUrls = await uploadListingImages(draft.images);
 
   const titleTrimmed = draft.title.trim();

--- a/Buyinz/tests/listings.test.ts
+++ b/Buyinz/tests/listings.test.ts
@@ -5,6 +5,7 @@ jest.mock('@/supabase/queries', () => ({
 import * as Queries from '@/supabase/queries';
 import {
   EMPTY_DRAFT,
+  getListingPriceValidationError,
   MAX_PHOTOS,
   isDraftValid,
   priceStringToDbValue,
@@ -57,8 +58,29 @@ describe('priceStringToDbValue', () => {
     expect(priceStringToDbValue('1e400')).toBeNull();
   });
 
-  it('parses leading-number prefix', () => {
-    expect(priceStringToDbValue('99usd')).toBe(99);
+  it('rejects leading-number suffix text', () => {
+    expect(priceStringToDbValue('99usd')).toBeNull();
+  });
+});
+
+describe('getListingPriceValidationError', () => {
+  it('allows empty price because it is optional', () => {
+    expect(getListingPriceValidationError('')).toBeNull();
+    expect(getListingPriceValidationError('   ')).toBeNull();
+  });
+
+  it('accepts valid prices within range', () => {
+    expect(getListingPriceValidationError('0')).toBeNull();
+    expect(getListingPriceValidationError('19.99')).toBeNull();
+    expect(getListingPriceValidationError('10000')).toBeNull();
+  });
+
+  it('rejects prices with too many decimal places', () => {
+    expect(getListingPriceValidationError('0.000001')).toMatch(/decimal/i);
+  });
+
+  it('rejects prices above the maximum', () => {
+    expect(getListingPriceValidationError('999999999')).toMatch(/10,000/i);
   });
 });
 
@@ -87,6 +109,14 @@ describe('isDraftValid', () => {
 
   it('allows zero price', () => {
     expect(isDraftValid(minimalValidDraft({ price: '0' }))).toBe(true);
+  });
+
+  it('rejects prices above the configured max', () => {
+    expect(isDraftValid(minimalValidDraft({ price: '999999999' }))).toBe(false);
+  });
+
+  it('rejects prices with too many decimals', () => {
+    expect(isDraftValid(minimalValidDraft({ price: '0.000001' }))).toBe(false);
   });
 });
 

--- a/Buyinz/tests/postsInsert-tests.ts
+++ b/Buyinz/tests/postsInsert-tests.ts
@@ -332,5 +332,12 @@ describe('postsInsert', () => {
 
       await expect(insertPost(baseDraft())).rejects.toThrow(dbError);
     });
+
+    it('rejects invalid prices before uploading images', async () => {
+      await expect(insertPost(baseDraft({ price: '999999999' }))).rejects.toThrow(
+        /10,000/i,
+      );
+      expect(mockUpload).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
Fixed #131 

Added strict listing price validation in lib/listingDraft.ts with a range of $0 to $10,000 and up to 2 decimal places.
The create listing screen now shows inline price errors and disables submit for out-of-range values in app/create-listing.tsx.
Backend insert logic now rejects invalid prices before uploads in supabase/postsInsert.ts.
Added coverage for valid, too-low/high, and malformed prices in tests/listings.test.ts and tests/postsInsert-tests.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added real-time validation feedback on the price input within the Create Listing screen
  * Price field displays validation error messages and formatting guidelines to help users enter correct values

* **Bug Fixes**
  * Enhanced price validation to enforce stricter numeric format requirements and range constraints, preventing invalid submissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->