### PR TITLE
bug fix: address validation

### DIFF
--- a/Buyinz/app/create-profile.tsx
+++ b/Buyinz/app/create-profile.tsx
@@ -85,6 +85,7 @@ export default function CreateProfileScreen() {
   const [isLoading, setIsLoading] = useState(false);
   const [usernameCheck, setUsernameCheck] = useState<UsernameCheck>('idle');
   const [showValidation, setShowValidation] = useState(false);
+  const [addressError, setAddressError] = useState<string | null>(null);
 
   useEffect(() => {
     if (phase !== 'onboarding') return;
@@ -368,10 +369,26 @@ export default function CreateProfileScreen() {
         throw new Error(formatCheck.message);
       }
 
-      const geo = await geocodeAddressString(address_string, {
-        expectedPostalCode: postalCode.trim(),
-        expectedRegion: regionNorm,
-      });
+      let geo;
+      try {
+        geo = await geocodeAddressString(address_string, {
+          expectedPostalCode: postalCode.trim(),
+          expectedRegion: regionNorm,
+        });
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : 'Could not locate address';
+        setAddressError(msg);
+        setIsLoading(false);
+        return;
+      }
+
+      // If geocoder returned non-blocking warnings (e.g. partial match),
+      // treat that as a blocking validation error for store onboarding.
+      if (geo?.warnings && Array.isArray(geo.warnings) && geo.warnings.length > 0) {
+        setAddressError(geo.warnings.join('\n\n'));
+        setIsLoading(false);
+        return;
+      }
 
       const profilePayload = {
         ...profilePayloadBase,
@@ -420,15 +437,17 @@ export default function CreateProfileScreen() {
 
   const userCoreFilled = !!displayName.trim() && !!normalizeUsername(username);
 
+  const storeAddressValidation = validateUsStoreAddressFormat({
+    address_line1: addressLine1,
+    city,
+    region,
+    postal_code: postalCode,
+  });
+
   const storeCoreFilled =
     !!displayName.trim() &&
     !!normalizeUsername(username) &&
-    validateUsStoreAddressFormat({
-      address_line1: addressLine1,
-      city,
-      region,
-      postal_code: postalCode,
-    }).ok;
+    storeAddressValidation.ok;
 
   const coreFilled =
     accountKind === 'user'
@@ -443,6 +462,9 @@ export default function CreateProfileScreen() {
     usernameCheck !== 'ok' ||
     onboardingSubphase !== 'form' ||
     !accountKind;
+
+  // Disable save while there's an address-level validation error (e.g. partial geocode match)
+  const effectiveSaveDisabled = saveDisabled || !!addressError;
 
   const headerTitle =
     phase === 'signIn' ? 'Sign in' : 'Complete your profile';
@@ -480,6 +502,10 @@ export default function CreateProfileScreen() {
 
   const fieldErr = (empty: boolean) =>
     showValidation && empty ? styles.inputError : undefined;
+
+  useEffect(() => {
+    setAddressError(null);
+  }, [addressLine1, city, region, postalCode]);
 
   return (
     <KeyboardAvoidingView
@@ -732,6 +758,7 @@ export default function CreateProfileScreen() {
                     styles.input,
                     { color: colors.text, borderColor: colors.border },
                     fieldErr(!addressLine1.trim()),
+                    !storeAddressValidation.ok && (showValidation || addressLine1 || city || region || postalCode) ? styles.inputError : undefined,
                   ]}
                   placeholder="Street address (Required)"
                   placeholderTextColor={colors.tabIconDefault}
@@ -743,6 +770,7 @@ export default function CreateProfileScreen() {
                     styles.input,
                     { color: colors.text, borderColor: colors.border },
                     fieldErr(!city.trim()),
+                    !storeAddressValidation.ok && (showValidation || addressLine1 || city || region || postalCode) ? styles.inputError : undefined,
                   ]}
                   placeholder="City (Required)"
                   placeholderTextColor={colors.tabIconDefault}
@@ -754,6 +782,7 @@ export default function CreateProfileScreen() {
                     styles.input,
                     { color: colors.text, borderColor: colors.border },
                     fieldErr(!region.trim()),
+                    !storeAddressValidation.ok && (showValidation || addressLine1 || city || region || postalCode) ? styles.inputError : undefined,
                   ]}
                   placeholder="State (2 letters, e.g. PA)"
                   placeholderTextColor={colors.tabIconDefault}
@@ -766,6 +795,7 @@ export default function CreateProfileScreen() {
                     styles.input,
                     { color: colors.text, borderColor: colors.border },
                     fieldErr(!postalCode.trim()),
+                    !storeAddressValidation.ok && (showValidation || addressLine1 || city || region || postalCode) ? styles.inputError : undefined,
                   ]}
                   placeholder="ZIP (5 digits or ZIP+4)"
                   placeholderTextColor={colors.tabIconDefault}
@@ -773,6 +803,12 @@ export default function CreateProfileScreen() {
                   onChangeText={setPostalCode}
                   keyboardType="numeric"
                 />
+                {/* Inline address validation message */}
+                {((!storeAddressValidation.ok && (showValidation || addressLine1 || city || region || postalCode)) || addressError) ? (
+                  <Text style={[styles.hint, { color: '#ef4444' }]}> 
+                    {addressError ?? (!storeAddressValidation.ok ? storeAddressValidation.message : null)}
+                  </Text>
+                ) : null}
               </>
             )}
 
@@ -797,10 +833,10 @@ export default function CreateProfileScreen() {
                 styles.primaryBtn,
                 { backgroundColor: colors.tint },
                 { marginTop: 16 },
-                saveDisabled && styles.primaryBtnDisabled,
+                effectiveSaveDisabled && styles.primaryBtnDisabled,
               ]}
               onPress={handleSave}
-              disabled={saveDisabled}
+              disabled={effectiveSaveDisabled}
             >
               {isLoading ? (
                 <ActivityIndicator color="#fff" />

--- a/Buyinz/package-lock.json
+++ b/Buyinz/package-lock.json
@@ -4020,7 +4020,7 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -5423,13 +5423,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "license": "ISC",
-      "peer": true
-    },
     "node_modules/bplist-creator": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.0.tgz",
@@ -6129,60 +6122,6 @@
         "hyphenate-style-name": "^1.0.3"
       }
     },
-    "node_modules/css-select": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-tree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "mdn-data": "2.0.14",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/css-tree/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">= 6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
     "node_modules/cssom": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
@@ -6214,7 +6153,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
@@ -6589,34 +6528,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/domelementtype": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "BSD-2-Clause",
-      "peer": true
-    },
     "node_modules/domexception": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
@@ -6639,37 +6550,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -6775,19 +6655,6 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-editor": {
@@ -11692,13 +11559,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/mdn-data": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-      "license": "CC0-1.0",
-      "peer": true
-    },
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
@@ -12372,19 +12232,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/nth-check": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "boolbase": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nullthrows": {
@@ -13533,22 +13380,6 @@
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
         "warn-once": "^0.1.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/react-native-svg": {
-      "version": "15.15.4",
-      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.15.4.tgz",
-      "integrity": "sha512-boT/vIRgj6zZKBpfTPJJiYWMbZE9duBMOwPK6kCSTgxsS947IFMOq9OgIFkpWZTB7t229H24pDRkh3W9ZK/J1A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "css-select": "^5.1.0",
-        "css-tree": "^1.1.3",
-        "warn-once": "0.1.1"
       },
       "peerDependencies": {
         "react": "*",


### PR DESCRIPTION
Fixes #129 and #132 

PR: Add inline validation for invalid store addresses
Summary
Improves store onboarding by showing clear address validation errors and blocking submission when the address cannot be fully matched.

Changes
Shows inline error text for invalid or partial store addresses
Highlights address fields when validation fails
Prevents Save and Verify Profile when geocoding returns a partial/general-area match
Surfaces geocode failures inline instead of only via a popup
Result
Users can no longer submit invalid addresses or mismatched city/address combinations without seeing why.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Address validation improved to block saves on geocoding failures or address warnings
  * Save button disabled whenever address errors are present
  * Inline red error messaging now shows geocode/address errors or format validation messages
  * Address errors clear automatically when users edit address fields, with visual highlighting for invalid inputs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->